### PR TITLE
Provides grpc configuration DSL and GrpcServer algebras

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ You could generate a reverse proxy and writing an endpoint as it's described [he
 To run the gateway:
 
 ```bash
-go run demo/gateway/server/entry.go
+go run demo/http/gateway/server/entry.go
 ```
 
 Then, you could use `curl` or similar to fetch the user over `HTTP`:

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,10 @@ lazy val rpc = project
   .settings(moduleName := "freestyle-rpc")
   .settings(
     Seq(
-      libraryDependencies ++= commonDeps ++ freestyleCoreDeps()
+      libraryDependencies ++= commonDeps ++ freestyleCoreDeps() ++
+        Seq(
+          "io.grpc" % "grpc-all" % "1.4.0"
+        )
     ): _*
   )
 

--- a/demo/greeting/src/main/scala/greeting/GreetingClientApp.scala
+++ b/demo/greeting/src/main/scala/greeting/GreetingClientApp.scala
@@ -22,7 +22,8 @@ object GreetingClientApp {
   def main(args: Array[String]): Unit = {
 
     val request = MessageRequest("Freestyle")
-    val client  = new GreetingClient(host, port)
+    val client  = new GreetingClient(host, portNode1)
+    // val client  = new GreetingClient(host, portNode2)
 
     // http://www.grpc.io/docs/guides/concepts.html
 

--- a/demo/greeting/src/main/scala/greeting/GreetingServerApp.scala
+++ b/demo/greeting/src/main/scala/greeting/GreetingServerApp.scala
@@ -18,11 +18,10 @@ package freestyle.rpc.demo
 package greeting
 
 import cats.implicits._
-import runtime.implicits._
 import freestyle.rpc.server._
 import freestyle.rpc.server.implicits._
+import runtime.implicits._
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
 import scala.concurrent.Await
 

--- a/demo/greeting/src/main/scala/greeting/runtime/implicits.scala
+++ b/demo/greeting/src/main/scala/greeting/runtime/implicits.scala
@@ -28,13 +28,14 @@ import scala.concurrent.{ExecutionContext, Future}
 
 object implicits {
 
-  implicit val config = Config(portNode1)
+  implicit val config: Config       = Config(portNode1)
+  implicit val ec: ExecutionContext = ExecutionContext.Implicits.global
 
   implicit val grpcConfigs: List[GrpcConfig] = List(
-    AddService(GreeterGrpc.bindService(new GreetingService, ExecutionContext.global))
+    AddService(GreeterGrpc.bindService(new GreetingService, ec))
   )
 
-  implicit val grpcServerKleisli =
+  implicit val grpcServerHandler =
     new GrpcServerHandler[Future] andThen new GrpcConfigInterpreter[Future]
 
 }

--- a/demo/greeting/src/main/scala/greeting/runtime/implicits.scala
+++ b/demo/greeting/src/main/scala/greeting/runtime/implicits.scala
@@ -14,12 +14,27 @@
  * limitations under the License.
  */
 
-package freestyle.rpc
+package freestyle.rpc.demo
+package greeting.runtime
 
-package object demo {
+import freestyle._
+import freestyle.implicits._
+import freestyle.rpc.demo.greeting._
+import freestyle.rpc.server._
+import freestyle.rpc.server.implicits._
+import freestyle.rpc.server.handlers._
 
-  val host      = "localhost"
-  val portNode1 = 50051
-  val portNode2 = 50052
+import scala.concurrent.{ExecutionContext, Future}
+
+object implicits {
+
+  implicit val config = Config(portNode1)
+
+  implicit val grpcConfigs: List[GrpcConfig] = List(
+    AddService(GreeterGrpc.bindService(new GreetingService, ExecutionContext.global))
+  )
+
+  implicit val grpcServerKleisli =
+    new GrpcServerHandler[Future] andThen new GrpcConfigInterpreter[Future]
 
 }

--- a/demo/http/src/main/scala/user/UserClientApp.scala
+++ b/demo/http/src/main/scala/user/UserClientApp.scala
@@ -24,7 +24,7 @@ object UserClientApp {
 
   def main(args: Array[String]): Unit = {
     val request = UserPassword("frees", "password")
-    val client  = new UserClient(host, port)
+    val client  = new UserClient(host, portNode1)
 
     val response = client.login(request)
 

--- a/demo/http/src/main/scala/user/UserServerApp.scala
+++ b/demo/http/src/main/scala/user/UserServerApp.scala
@@ -18,11 +18,10 @@ package freestyle.rpc.demo
 package user
 
 import cats.implicits._
-import runtime.implicits._
 import freestyle.rpc.server._
 import freestyle.rpc.server.implicits._
+import runtime.implicits._
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
 import scala.concurrent.Await
 

--- a/demo/http/src/main/scala/user/UserServerApp.scala
+++ b/demo/http/src/main/scala/user/UserServerApp.scala
@@ -17,20 +17,17 @@
 package freestyle.rpc.demo
 package user
 
-import freestyle.rpc.demo.greeting.GrpcServer
+import cats.implicits._
+import runtime.implicits._
+import freestyle.rpc.server._
+import freestyle.rpc.server.implicits._
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.Duration
+import scala.concurrent.Await
 
 object UserServerApp {
 
-  def main(args: Array[String]): Unit = {
-
-    val serverServiceDefinition =
-      UserServiceGrpc.bindService(new UserService, ExecutionContext.global)
-    val server = new GrpcServer(serverServiceDefinition)
-
-    server.start()
-    server.blockUntilShutdown()
-  }
-
+  def main(args: Array[String]): Unit =
+    Await.result(server[GrpcServer.Op].bootstrapFuture, Duration.Inf)
 }

--- a/demo/http/src/main/scala/user/runtime/implicits.scala
+++ b/demo/http/src/main/scala/user/runtime/implicits.scala
@@ -15,19 +15,26 @@
  */
 
 package freestyle.rpc.demo
-package greeting
+package user.runtime
 
-import cats.implicits._
-import runtime.implicits._
+import freestyle._
+import freestyle.implicits._
+import freestyle.rpc.demo.user.{UserService, UserServiceGrpc}
 import freestyle.rpc.server._
 import freestyle.rpc.server.implicits._
+import freestyle.rpc.server.handlers._
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration.Duration
-import scala.concurrent.Await
+import scala.concurrent.{ExecutionContext, Future}
 
-object GreetingServerApp {
+object implicits {
 
-  def main(args: Array[String]): Unit =
-    Await.result(server[GrpcServer.Op].bootstrapFuture, Duration.Inf)
+  implicit val config = Config(portNode1)
+
+  implicit val grpcConfigs: List[GrpcConfig] = List(
+    AddService(UserServiceGrpc.bindService(new UserService, ExecutionContext.global))
+  )
+
+  implicit val grpcServerKleisli =
+    new GrpcServerHandler[Future] andThen new GrpcConfigInterpreter[Future]
+
 }

--- a/demo/http/src/main/scala/user/runtime/implicits.scala
+++ b/demo/http/src/main/scala/user/runtime/implicits.scala
@@ -19,7 +19,7 @@ package user.runtime
 
 import freestyle._
 import freestyle.implicits._
-import freestyle.rpc.demo.user.{UserService, UserServiceGrpc}
+import freestyle.rpc.demo.user._
 import freestyle.rpc.server._
 import freestyle.rpc.server.implicits._
 import freestyle.rpc.server.handlers._
@@ -28,13 +28,14 @@ import scala.concurrent.{ExecutionContext, Future}
 
 object implicits {
 
-  implicit val config = Config(portNode1)
+  implicit val config: Config       = Config(portNode1)
+  implicit val ec: ExecutionContext = ExecutionContext.Implicits.global
 
   implicit val grpcConfigs: List[GrpcConfig] = List(
     AddService(UserServiceGrpc.bindService(new UserService, ExecutionContext.global))
   )
 
-  implicit val grpcServerKleisli =
+  implicit val grpcServerHandler =
     new GrpcServerHandler[Future] andThen new GrpcConfigInterpreter[Future]
 
 }

--- a/rpc/src/main/scala/server/GrpcConfig.scala
+++ b/rpc/src/main/scala/server/GrpcConfig.scala
@@ -24,9 +24,9 @@ import io.grpc._
 
 case class Config(port: Int)
 
-sealed trait GrpcConfig
+sealed trait GrpcConfig extends Product with Serializable
 
-case object GetDirectExecutor extends GrpcConfig
+case object DirectExecutor extends GrpcConfig
 
 case class SetExecutor(executor: Executor) extends GrpcConfig
 

--- a/rpc/src/main/scala/server/GrpcConfig.scala
+++ b/rpc/src/main/scala/server/GrpcConfig.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc
+package server
+
+import java.io.File
+import java.util.concurrent.Executor
+
+import io.grpc._
+
+case class Config(port: Int)
+
+sealed trait GrpcConfig
+
+case object GetDirectExecutor extends GrpcConfig
+
+case class SetExecutor(executor: Executor) extends GrpcConfig
+
+case class AddService(service: ServerServiceDefinition) extends GrpcConfig
+
+case class AddBindableService(bindableService: BindableService) extends GrpcConfig
+
+case class AddTransportFilter(filter: ServerTransportFilter) extends GrpcConfig
+
+case class AddStreamTracerFactory(factory: ServerStreamTracer.Factory) extends GrpcConfig
+
+case class SetFallbackHandlerRegistry(fallbackRegistry: HandlerRegistry) extends GrpcConfig
+
+case class UseTransportSecurity(certChain: File, privateKey: File) extends GrpcConfig
+
+case class SetDecompressorRegistry(registry: DecompressorRegistry) extends GrpcConfig
+
+case class SetCompressorRegistry(registry: CompressorRegistry) extends GrpcConfig

--- a/rpc/src/main/scala/server/GrpcServer.scala
+++ b/rpc/src/main/scala/server/GrpcServer.scala
@@ -14,31 +14,37 @@
  * limitations under the License.
  */
 
-package freestyle.rpc.demo
-package greeting
+package freestyle.rpc
+package server
 
-import io.grpc.{Server, ServerBuilder, ServerServiceDefinition}
+import freestyle._
+import io.grpc._
 
-class GrpcServer(serverServiceDefinition: ServerServiceDefinition) {
+import scala.concurrent.duration.TimeUnit
 
-  var server: Option[Server] = None
+@free
+trait GrpcServer {
 
-  def start(): Unit = {
-    server = Option(
-      ServerBuilder
-        .forPort(port)
-        .addService(serverServiceDefinition)
-        .build
-        .start
-    )
+  def start(): FS[Server]
 
-    Runtime.getRuntime.addShutdownHook(new Thread() {
-      override def run(): Unit = stopServer()
-    })
-  }
+  def getPort: FS[Int]
 
-  def stopServer(): Unit = server.foreach(_.shutdown())
+  def getServices: FS[List[ServerServiceDefinition]]
 
-  def blockUntilShutdown(): Unit =
-    server.foreach(_.awaitTermination())
+  def getImmutableServices: FS[List[ServerServiceDefinition]]
+
+  def getMutableServices: FS[List[ServerServiceDefinition]]
+
+  def shutdown(): FS[Server]
+
+  def shutdownNow(): FS[Server]
+
+  def isShutdown: FS[Boolean]
+
+  def isTerminated: FS[Boolean]
+
+  def awaitTerminationTimeout(timeout: Long, unit: TimeUnit): FS[Boolean]
+
+  def awaitTermination(): FS[Unit]
+
 }

--- a/rpc/src/main/scala/server/handlers/GrpcServerHandler.scala
+++ b/rpc/src/main/scala/server/handlers/GrpcServerHandler.scala
@@ -37,31 +37,34 @@ class GrpcServerHandler[F[_]](implicit C: Capture[F])
       }
     })
 
-    Kleisli(s => C.capture(s.start()))
+    captureWithServer(_.start())
   }
 
-  def getPort: GrpcServerOps[F, Int] = Kleisli(s => C.capture(s.getPort))
+  def getPort: GrpcServerOps[F, Int] = captureWithServer(_.getPort)
 
   def getServices: GrpcServerOps[F, List[ServerServiceDefinition]] =
-    Kleisli(s => C.capture(s.getServices.asScala.toList))
+    captureWithServer(_.getServices.asScala.toList)
 
   def getImmutableServices: GrpcServerOps[F, List[ServerServiceDefinition]] =
-    Kleisli(s => C.capture(s.getImmutableServices.asScala.toList))
+    captureWithServer(_.getImmutableServices.asScala.toList)
 
   def getMutableServices: GrpcServerOps[F, List[ServerServiceDefinition]] =
-    Kleisli(s => C.capture(s.getMutableServices.asScala.toList))
+    captureWithServer(_.getMutableServices.asScala.toList)
 
-  def shutdown: GrpcServerOps[F, Server] = Kleisli(s => C.capture(s.shutdown()))
+  def shutdown: GrpcServerOps[F, Server] = captureWithServer(_.shutdown())
 
-  def shutdownNow: GrpcServerOps[F, Server] = Kleisli(s => C.capture(s.shutdownNow()))
+  def shutdownNow: GrpcServerOps[F, Server] = captureWithServer(_.shutdownNow())
 
-  def isShutdown: GrpcServerOps[F, Boolean] = Kleisli(s => C.capture(s.isShutdown))
+  def isShutdown: GrpcServerOps[F, Boolean] = captureWithServer(_.isShutdown)
 
-  def isTerminated: GrpcServerOps[F, Boolean] = Kleisli(s => C.capture(s.isTerminated))
+  def isTerminated: GrpcServerOps[F, Boolean] = captureWithServer(_.isTerminated)
 
   def awaitTerminationTimeout(timeout: Long, unit: TimeUnit): GrpcServerOps[F, Boolean] =
-    Kleisli(s => C.capture(s.awaitTermination(timeout, unit)))
+    captureWithServer(_.awaitTermination(timeout, unit))
 
-  def awaitTermination: GrpcServerOps[F, Unit] = Kleisli(s => C.capture(s.awaitTermination()))
+  def awaitTermination: GrpcServerOps[F, Unit] = captureWithServer(_.awaitTermination())
+
+  private[this] def captureWithServer[A](f: Server => A): GrpcServerOps[F, A] =
+    Kleisli(s => C.capture(f(s)))
 
 }

--- a/rpc/src/main/scala/server/handlers/GrpcServerHandler.scala
+++ b/rpc/src/main/scala/server/handlers/GrpcServerHandler.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc
+package server.handlers
+
+import cats.data.Kleisli
+import freestyle.rpc.server.{GrpcServer, GrpcServerOps}
+import freestyle.Capture
+import io.grpc.{Server, ServerServiceDefinition}
+
+import scala.collection.JavaConverters._
+import scala.concurrent.duration.TimeUnit
+
+class GrpcServerHandler[F[_]](implicit C: Capture[F])
+    extends GrpcServer.Handler[GrpcServerOps[F, ?]] {
+
+  def start: GrpcServerOps[F, Server] = {
+
+    Runtime.getRuntime.addShutdownHook(new Thread() {
+      override def run(): Unit = {
+        shutdown
+        (): Unit
+      }
+    })
+
+    Kleisli(s => C.capture(s.start()))
+  }
+
+  def getPort: GrpcServerOps[F, Int] = Kleisli(s => C.capture(s.getPort))
+
+  def getServices: GrpcServerOps[F, List[ServerServiceDefinition]] =
+    Kleisli(s => C.capture(s.getServices.asScala.toList))
+
+  def getImmutableServices: GrpcServerOps[F, List[ServerServiceDefinition]] =
+    Kleisli(s => C.capture(s.getImmutableServices.asScala.toList))
+
+  def getMutableServices: GrpcServerOps[F, List[ServerServiceDefinition]] =
+    Kleisli(s => C.capture(s.getMutableServices.asScala.toList))
+
+  def shutdown: GrpcServerOps[F, Server] = Kleisli(s => C.capture(s.shutdown()))
+
+  def shutdownNow: GrpcServerOps[F, Server] = Kleisli(s => C.capture(s.shutdownNow()))
+
+  def isShutdown: GrpcServerOps[F, Boolean] = Kleisli(s => C.capture(s.isShutdown))
+
+  def isTerminated: GrpcServerOps[F, Boolean] = Kleisli(s => C.capture(s.isTerminated))
+
+  def awaitTerminationTimeout(timeout: Long, unit: TimeUnit): GrpcServerOps[F, Boolean] =
+    Kleisli(s => C.capture(s.awaitTermination(timeout, unit)))
+
+  def awaitTermination: GrpcServerOps[F, Unit] = Kleisli(s => C.capture(s.awaitTermination()))
+
+}

--- a/rpc/src/main/scala/server/implicits.scala
+++ b/rpc/src/main/scala/server/implicits.scala
@@ -18,17 +18,10 @@ package freestyle.rpc
 package server
 
 import cats.{~>, Monad}
-import freestyle.{Capture, FreeS}
 import freestyle._
 import freestyle.implicits._
 
 import scala.concurrent.Future
-
-trait FutureCaptureInstance {
-  implicit val `scala.concurrent.FutureCaptureInstance`: Capture[Future] = new Capture[Future] {
-    override def capture[A](a: ⇒ A): Future[A] = Future.successful(a)
-  }
-}
 
 trait Syntax {
 
@@ -47,7 +40,7 @@ trait Syntax {
   }
 }
 
-object implicits extends FutureCaptureInstance with Syntax {
+object implicits extends CaptureInstances with Syntax {
 
   def server[F[_]](implicit app: GrpcServer[F]): FreeS[F, Unit] = {
     for {

--- a/rpc/src/main/scala/server/implicits.scala
+++ b/rpc/src/main/scala/server/implicits.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc
+package server
+
+import cats.{~>, Monad}
+import freestyle.{Capture, FreeS}
+import freestyle._
+import freestyle.implicits._
+
+import scala.concurrent.Future
+
+trait FutureCaptureInstance {
+  implicit val `scala.concurrent.FutureCaptureInstance`: Capture[Future] = new Capture[Future] {
+    override def capture[A](a: ⇒ A): Future[A] = Future.successful(a)
+  }
+}
+
+trait Syntax {
+
+  implicit def serverOps(server: FreeS[GrpcServer.Op, Unit]): ServerOps = new ServerOps(server)
+
+  final class ServerOps(server: FreeS[GrpcServer.Op, Unit]) {
+
+    def bootstrapM[M[_]](implicit MM: Monad[M], handler: GrpcServer.Op ~> M): M[Unit] =
+      server.interpret[M]
+
+    def bootstrapFuture(
+        implicit MF: Monad[Future],
+        handler: GrpcServer.Op ~> Future): Future[Unit] =
+      server.interpret[Future]
+
+  }
+}
+
+object implicits extends FutureCaptureInstance with Syntax {
+
+  def server[F[_]](implicit app: GrpcServer[F]): FreeS[F, Unit] = {
+    for {
+      _ <- app.start()
+      _ <- app.awaitTermination()
+    } yield ()
+  }
+}

--- a/rpc/src/main/scala/server/package.scala
+++ b/rpc/src/main/scala/server/package.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc
+
+import cats.data.Kleisli
+import cats.~>
+import io.grpc._
+
+package object server {
+
+  type GrpcServerOps[F[_], A] = Kleisli[F, Server, A]
+
+  class GrpcConfigInterpreter[F[_]](implicit initConfig: Config, configList: List[GrpcConfig])
+      extends (Kleisli[F, Server, ?] ~> F) {
+
+    private[this] def interpret(configOptions: List[GrpcConfig])(
+        implicit initConfig: Config): Server =
+      configOptions
+        .foldLeft[ServerBuilder[_]](ServerBuilder.forPort(initConfig.port))((acc, option) =>
+          (option match {
+            case GetDirectExecutor               => acc.directExecutor()
+            case SetExecutor(ex)                 => acc.executor(ex)
+            case AddService(srv)                 => acc.addService(srv)
+            case AddBindableService(srv)         => acc.addService(srv)
+            case AddTransportFilter(filter)      => acc.addTransportFilter(filter)
+            case AddStreamTracerFactory(factory) => acc.addStreamTracerFactory(factory)
+            case SetFallbackHandlerRegistry(fr)  => acc.fallbackHandlerRegistry(fr)
+            case UseTransportSecurity(cc, pk)    => acc.useTransportSecurity(cc, pk)
+            case SetDecompressorRegistry(dr)     => acc.decompressorRegistry(dr)
+            case SetCompressorRegistry(cr)       => acc.compressorRegistry(cr)
+          }).asInstanceOf[ServerBuilder[_]])
+        .build()
+
+    private[this] def build(configList: List[GrpcConfig]): Server = interpret(configList)
+
+    override def apply[B](fa: Kleisli[F, Server, B]): F[B] =
+      fa(build(configList))
+
+  }
+}

--- a/rpc/src/main/scala/server/package.scala
+++ b/rpc/src/main/scala/server/package.scala
@@ -32,7 +32,7 @@ package object server {
       configOptions
         .foldLeft[ServerBuilder[_]](ServerBuilder.forPort(initConfig.port))((acc, option) =>
           (option match {
-            case GetDirectExecutor               => acc.directExecutor()
+            case DirectExecutor                  => acc.directExecutor()
             case SetExecutor(ex)                 => acc.executor(ex)
             case AddService(srv)                 => acc.addService(srv)
             case AddBindableService(srv)         => acc.addService(srv)


### PR DESCRIPTION
Server Demo has been also adapted to the newly introduced changes, where the RPC core provides helpers in order to bootstrap the server in the runtime monad, according to the server configuration.

This is a preliminary version towards to fulfill https://github.com/frees-io/freestyle-rpc/issues/10. We still need to find the way to aggregate all the services which would run in such a server.

For now, the user has to provide an implicit list with all the services the server will register:

https://github.com/frees-io/freestyle-rpc/compare/feature/server-definitions#diff-09bc282791d5598d8a70f248fbb125b0R33

Thanks @peterneyens for your suggestions related to the `GrpcConfigInterpreter` :)

Server bootstrap:

```scala
import cats.implicits._
import runtime.implicits._
import freestyle.rpc.server._
import freestyle.rpc.server.implicits._

import scala.concurrent.ExecutionContext.Implicits.global
import scala.concurrent.duration.Duration
import scala.concurrent.Await

object GreetingServerApp {

  def main(args: Array[String]): Unit =
    Await.result(server[GrpcServer.Op].bootstrapFuture, Duration.Inf)
}
```

(`bootstrapFuture` would be equivalent to `bootstrap[Future]`)

Runtime dependencies:

```scala
import freestyle._
import freestyle.implicits._
import freestyle.rpc.demo.greeting._
import freestyle.rpc.server._
import freestyle.rpc.server.implicits._
import freestyle.rpc.server.handlers._

import scala.concurrent.{ExecutionContext, Future}

object implicits {

  implicit val config = Config(portNode1)

  implicit val grpcConfigs: List[GrpcConfig] = List(
    AddService(GreeterGrpc.bindService(new GreetingService, ExecutionContext.global))
  )

  implicit val grpcServerKleisli =
    new GrpcServerHandler[Future] andThen new GrpcConfigInterpreter[Future]

}
```