### PR TITLE
Client Definitions based on free algebras - Unary Services 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,7 @@ lazy val rpc = project
     Seq(
       libraryDependencies ++= commonDeps ++ freestyleCoreDeps() ++
         Seq(
+          %%("freestyle-async"),
           "io.grpc" % "grpc-all" % "1.4.0"
         )
     ): _*
@@ -31,6 +32,9 @@ lazy val `demo-greeting` = project
   .settings(noPublishSettings: _*)
   .settings(commandAliases: _*)
   .settings(demoCommonSettings: _*)
+  .settings(Seq(
+    libraryDependencies += %%("freestyle-async")
+  ): _*)
 
 lazy val googleApi = project
   .in(file("third_party"))

--- a/demo/greeting/src/main/scala/greeting/GreetingClient.scala
+++ b/demo/greeting/src/main/scala/greeting/GreetingClient.scala
@@ -19,12 +19,11 @@ package greeting
 
 import java.util.concurrent.{CountDownLatch, TimeUnit}
 
-import io.grpc.ManagedChannelBuilder
 import freestyle.rpc.demo.greeting.GreeterGrpc._
+import io.grpc.ManagedChannelBuilder
 import io.grpc.stub.StreamObserver
 
 import scala.collection.immutable
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{Await, Future, Promise}
 import scala.concurrent.duration._
 import scala.util.Random
@@ -35,18 +34,6 @@ class GreetingClient(host: String, port: Int) {
     ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build
 
   private[this] val asyncHelloClient: GreeterStub = GreeterGrpc.stub(channel)
-
-  def unaryDemo(request: MessageRequest): Unit = {
-
-    val response = for {
-      hi  <- asyncHelloClient.sayHello(request)
-      bye <- asyncHelloClient.sayGoodbye(request)
-    } yield (hi.message, bye.message)
-
-    println("")
-    println(s"Received -> ${Await.result(response, Duration.Inf)}")
-    println("")
-  }
 
   def serverStreamingDemo(request: MessageRequest): Future[Unit] = {
     val lotOfRepliesStreamingPromise = Promise[Unit]()

--- a/demo/greeting/src/main/scala/greeting/GreetingClientApp.scala
+++ b/demo/greeting/src/main/scala/greeting/GreetingClientApp.scala
@@ -17,7 +17,6 @@
 package freestyle.rpc.demo
 package greeting
 
-import cats._
 import cats.implicits._
 import freestyle._
 import freestyle.implicits._
@@ -62,7 +61,7 @@ object GreetingClientApp {
     }
   }
 
-  def runProgram[F[_]](implicit M: Monad[F]): Unit = {
+  def main(args: Array[String]): Unit = {
 
     Await.result(unaryDemo[ClientAPP.Op].interpret[Future], Duration.Inf)
 
@@ -88,11 +87,6 @@ object GreetingClientApp {
 
     client.biStreamingDemo()
 
-    (): Unit
-  }
-
-  def main(args: Array[String]): Unit = {
-    runProgram[Future]
     (): Unit
   }
 }

--- a/demo/greeting/src/main/scala/greeting/GreetingServerApp.scala
+++ b/demo/greeting/src/main/scala/greeting/GreetingServerApp.scala
@@ -20,7 +20,7 @@ package greeting
 import cats.implicits._
 import freestyle.rpc.server._
 import freestyle.rpc.server.implicits._
-import runtime.implicits.server._
+import runtime.server.implicits._
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.Await

--- a/demo/greeting/src/main/scala/greeting/client/EchoClientM.scala
+++ b/demo/greeting/src/main/scala/greeting/client/EchoClientM.scala
@@ -34,7 +34,7 @@ trait EchoClientM {
       options: CallOptions = CallOptions.DEFAULT): FS.Seq[EchoResponse] =
     for {
       call     <- channelOps.newCall(EchoServiceGrpc.METHOD_ECHO, options)
-      response <- clientCallsM.futureUnaryCall(call, request)
+      response <- clientCallsM.asyncM(call, request)
     } yield response
 
 }

--- a/demo/greeting/src/main/scala/greeting/client/EchoClientM.scala
+++ b/demo/greeting/src/main/scala/greeting/client/EchoClientM.scala
@@ -15,18 +15,26 @@
  */
 
 package freestyle.rpc.demo
-package greeting
+package greeting.client
 
-import cats.implicits._
-import freestyle.rpc.server._
-import freestyle.rpc.server.implicits._
-import runtime.implicits.server._
+import freestyle._
+import freestyle.rpc.client._
+import freestyle.rpc.demo.echo.EchoServiceGrpc
+import freestyle.rpc.demo.echo_messages._
+import io.grpc.CallOptions
 
-import scala.concurrent.duration.Duration
-import scala.concurrent.Await
+@module
+trait EchoClientM {
 
-object GreetingServerApp {
+  val clientCallsM: ClientCallsM
+  val channelOps: ChannelM
 
-  def main(args: Array[String]): Unit =
-    Await.result(server[GrpcServer.Op].bootstrapFuture, Duration.Inf)
+  def echo(
+      request: EchoRequest,
+      options: CallOptions = CallOptions.DEFAULT): FS.Seq[EchoResponse] =
+    for {
+      call     <- channelOps.newCall(EchoServiceGrpc.METHOD_ECHO, options)
+      response <- clientCallsM.futureUnaryCall(call, request)
+    } yield response
+
 }

--- a/demo/greeting/src/main/scala/greeting/client/GreetingClientM.scala
+++ b/demo/greeting/src/main/scala/greeting/client/GreetingClientM.scala
@@ -34,7 +34,7 @@ trait GreetingClientM {
       options: CallOptions = CallOptions.DEFAULT): FS.Seq[MessageReply] =
     for {
       call     <- channelOps.newCall(GreeterGrpc.METHOD_SAY_HELLO, options)
-      response <- clientCallsM.futureUnaryCall(call, request)
+      response <- clientCallsM.asyncM(call, request)
     } yield response
 
   def sayGoodbye(
@@ -42,7 +42,7 @@ trait GreetingClientM {
       options: CallOptions = CallOptions.DEFAULT): FS.Seq[MessageReply] =
     for {
       call     <- channelOps.newCall(GreeterGrpc.METHOD_SAY_GOODBYE, options)
-      response <- clientCallsM.futureUnaryCall(call, request)
+      response <- clientCallsM.asyncM(call, request)
     } yield response
 
   def lotsOfReplies(
@@ -51,7 +51,7 @@ trait GreetingClientM {
       options: CallOptions = CallOptions.DEFAULT): FS.Seq[Unit] =
     for {
       call     <- channelOps.newCall(GreeterGrpc.METHOD_LOTS_OF_REPLIES, options)
-      response <- clientCallsM.asyncServerStreamingCall(call, request, responseObserver)
+      response <- clientCallsM.asyncStreamServer(call, request, responseObserver)
     } yield response
 
   def lotsOfGreetings(
@@ -59,7 +59,7 @@ trait GreetingClientM {
       options: CallOptions = CallOptions.DEFAULT): FS.Seq[StreamObserver[MessageRequest]] =
     for {
       call     <- channelOps.newCall(GreeterGrpc.METHOD_LOTS_OF_GREETINGS, options)
-      response <- clientCallsM.asyncClientStreamingCall(call, responseObserver)
+      response <- clientCallsM.asyncStreamClient(call, responseObserver)
     } yield response
 
   def bidiHello(
@@ -67,7 +67,7 @@ trait GreetingClientM {
       options: CallOptions = CallOptions.DEFAULT): FS.Seq[StreamObserver[MessageRequest]] =
     for {
       call     <- channelOps.newCall(GreeterGrpc.METHOD_BIDI_HELLO, options)
-      response <- clientCallsM.asyncBidiStreamingCall(call, responseObserver)
+      response <- clientCallsM.asyncStreamBidi(call, responseObserver)
     } yield response
 
 }

--- a/demo/greeting/src/main/scala/greeting/client/GreetingClientM.scala
+++ b/demo/greeting/src/main/scala/greeting/client/GreetingClientM.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc.demo
+package greeting.client
+
+import freestyle._
+import freestyle.rpc.client._
+import freestyle.rpc.demo.greeting._
+import io.grpc.CallOptions
+import io.grpc.stub.StreamObserver
+
+@module
+trait GreetingClientM {
+
+  val clientCallsM: ClientCallsM
+  val channelOps: ChannelM
+
+  def sayHello(
+      request: MessageRequest,
+      options: CallOptions = CallOptions.DEFAULT): FS.Seq[MessageReply] =
+    for {
+      call     <- channelOps.newCall(GreeterGrpc.METHOD_SAY_HELLO, options)
+      response <- clientCallsM.futureUnaryCall(call, request)
+    } yield response
+
+  def sayGoodbye(
+      request: MessageRequest,
+      options: CallOptions = CallOptions.DEFAULT): FS.Seq[MessageReply] =
+    for {
+      call     <- channelOps.newCall(GreeterGrpc.METHOD_SAY_GOODBYE, options)
+      response <- clientCallsM.futureUnaryCall(call, request)
+    } yield response
+
+  def lotsOfReplies(
+      request: MessageRequest,
+      responseObserver: StreamObserver[MessageReply],
+      options: CallOptions = CallOptions.DEFAULT): FS.Seq[Unit] =
+    for {
+      call     <- channelOps.newCall(GreeterGrpc.METHOD_LOTS_OF_REPLIES, options)
+      response <- clientCallsM.asyncServerStreamingCall(call, request, responseObserver)
+    } yield response
+
+  def lotsOfGreetings(
+      responseObserver: StreamObserver[MessageReply],
+      options: CallOptions = CallOptions.DEFAULT): FS.Seq[StreamObserver[MessageRequest]] =
+    for {
+      call     <- channelOps.newCall(GreeterGrpc.METHOD_LOTS_OF_GREETINGS, options)
+      response <- clientCallsM.asyncClientStreamingCall(call, responseObserver)
+    } yield response
+
+  def bidiHello(
+      responseObserver: StreamObserver[MessageReply],
+      options: CallOptions = CallOptions.DEFAULT): FS.Seq[StreamObserver[MessageRequest]] =
+    for {
+      call     <- channelOps.newCall(GreeterGrpc.METHOD_BIDI_HELLO, options)
+      response <- clientCallsM.asyncBidiStreamingCall(call, responseObserver)
+    } yield response
+
+}

--- a/rpc/src/main/scala/client/ChannelConfig.scala
+++ b/rpc/src/main/scala/client/ChannelConfig.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc
+package client
+
+import java.util.concurrent.{Executor, TimeUnit}
+
+import io.grpc._
+
+sealed trait ManagedChannelFor                               extends Product with Serializable
+case class ManagedChannelForAddress(name: String, port: Int) extends ManagedChannelFor
+case class ManagedChannelForTarget(target: String)           extends ManagedChannelFor
+
+sealed trait ManagedChannelConfig                                     extends Product with Serializable
+case object DirectExecutor                                            extends ManagedChannelConfig
+case class SetExecutor(executor: Executor)                            extends ManagedChannelConfig
+case class AddInterceptorList(interceptors: List[ClientInterceptor])  extends ManagedChannelConfig
+case class AddInterceptor(interceptors: ClientInterceptor*)           extends ManagedChannelConfig
+case class UserAgent(userAgent: String)                               extends ManagedChannelConfig
+case class OverrideAuthority(authority: String)                       extends ManagedChannelConfig
+case class UsePlaintext(skipNegotiation: Boolean)                     extends ManagedChannelConfig
+case class NameResolverFactory(resolverFactory: NameResolver.Factory) extends ManagedChannelConfig
+case class LoadBalancerFactory(lbFactory: LoadBalancer.Factory)       extends ManagedChannelConfig
+case class SetDecompressorRegistry(registry: DecompressorRegistry)    extends ManagedChannelConfig
+case class SetCompressorRegistry(registry: CompressorRegistry)        extends ManagedChannelConfig
+case class SetIdleTimeout(value: Long, unit: TimeUnit)                extends ManagedChannelConfig
+case class SetMaxInboundMessageSize(max: Int)                         extends ManagedChannelConfig

--- a/rpc/src/main/scala/client/ChannelM.scala
+++ b/rpc/src/main/scala/client/ChannelM.scala
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-package freestyle.rpc.demo
-package greeting
+package freestyle.rpc
+package client
 
-import cats.implicits._
-import freestyle.rpc.server._
-import freestyle.rpc.server.implicits._
-import runtime.implicits.server._
+import freestyle._
+import io.grpc.{CallOptions, ClientCall, MethodDescriptor}
 
-import scala.concurrent.duration.Duration
-import scala.concurrent.Await
+@free
+trait ChannelM {
 
-object GreetingServerApp {
+  def newCall[I, O](
+      methodDescriptor: MethodDescriptor[I, O],
+      callOptions: CallOptions): FS[ClientCall[I, O]]
 
-  def main(args: Array[String]): Unit =
-    Await.result(server[GrpcServer.Op].bootstrapFuture, Duration.Inf)
+  def authority: FS[String]
+
 }

--- a/rpc/src/main/scala/client/ClientCallsM.scala
+++ b/rpc/src/main/scala/client/ClientCallsM.scala
@@ -24,37 +24,37 @@ import io.grpc.stub.StreamObserver
 @free
 trait ClientCallsM {
 
-  def asyncUnaryCall[I, O](call: ClientCall[I, O], param: I, observer: StreamObserver[O]): FS[Unit]
+  def async[I, O](call: ClientCall[I, O], param: I, observer: StreamObserver[O]): FS[Unit]
 
-  def asyncServerStreamingCall[I, O](
+  def asyncStreamServer[I, O](
       call: ClientCall[I, O],
       param: I,
       responseObserver: StreamObserver[O]): FS[Unit]
 
-  def asyncClientStreamingCall[I, O](
+  def asyncStreamClient[I, O](
       call: ClientCall[I, O],
       responseObserver: StreamObserver[O]): FS[StreamObserver[I]]
 
-  def asyncBidiStreamingCall[I, O](
+  def asyncStreamBidi[I, O](
       call: ClientCall[I, O],
       responseObserver: StreamObserver[O]): FS[StreamObserver[I]]
 
-  def blockingUnaryCall[I, O](call: ClientCall[I, O], param: I): FS[O]
+  def sync[I, O](call: ClientCall[I, O], param: I): FS[O]
 
-  def blockingUnaryCallChannel[I, O](
+  def syncC[I, O](
       channel: Channel,
       method: MethodDescriptor[I, O],
       callOptions: CallOptions,
       param: I): FS[O]
 
-  def blockingServerStreamingCall[I, O](call: ClientCall[I, O], param: I): FS[Iterator[O]]
+  def syncStreamServer[I, O](call: ClientCall[I, O], param: I): FS[Iterator[O]]
 
-  def blockingServerStreamingCallChannel[I, O](
+  def syncStreamServerC[I, O](
       channel: Channel,
       method: MethodDescriptor[I, O],
       callOptions: CallOptions,
       param: I): FS[Iterator[O]]
 
-  def futureUnaryCall[I, O](call: ClientCall[I, O], param: I): FS[O]
+  def asyncM[I, O](call: ClientCall[I, O], param: I): FS[O]
 
 }

--- a/rpc/src/main/scala/client/ClientCallsM.scala
+++ b/rpc/src/main/scala/client/ClientCallsM.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc
+package client
+
+import freestyle.free
+import io.grpc._
+import io.grpc.stub.StreamObserver
+
+@free
+trait ClientCallsM {
+
+  def asyncUnaryCall[I, O](call: ClientCall[I, O], param: I, observer: StreamObserver[O]): FS[Unit]
+
+  def asyncServerStreamingCall[I, O](
+      call: ClientCall[I, O],
+      param: I,
+      responseObserver: StreamObserver[O]): FS[Unit]
+
+  def asyncClientStreamingCall[I, O](
+      call: ClientCall[I, O],
+      responseObserver: StreamObserver[O]): FS[StreamObserver[I]]
+
+  def asyncBidiStreamingCall[I, O](
+      call: ClientCall[I, O],
+      responseObserver: StreamObserver[O]): FS[StreamObserver[I]]
+
+  def blockingUnaryCall[I, O](call: ClientCall[I, O], param: I): FS[O]
+
+  def blockingUnaryCallChannel[I, O](
+      channel: Channel,
+      method: MethodDescriptor[I, O],
+      callOptions: CallOptions,
+      param: I): FS[O]
+
+  def blockingServerStreamingCall[I, O](call: ClientCall[I, O], param: I): FS[Iterator[O]]
+
+  def blockingServerStreamingCallChannel[I, O](
+      channel: Channel,
+      method: MethodDescriptor[I, O],
+      callOptions: CallOptions,
+      param: I): FS[Iterator[O]]
+
+  def futureUnaryCall[I, O](call: ClientCall[I, O], param: I): FS[O]
+
+}

--- a/rpc/src/main/scala/client/handlers/ChannelMHandler.scala
+++ b/rpc/src/main/scala/client/handlers/ChannelMHandler.scala
@@ -22,14 +22,14 @@ import freestyle.Capture
 import freestyle.rpc.client.{ChannelM, ManagedChannelOps}
 import io.grpc.{CallOptions, ClientCall, MethodDescriptor}
 
-class ChannelMHandler[F[_]](implicit C: Capture[F])
-    extends ChannelM.Handler[ManagedChannelOps[F, ?]] {
+class ChannelMHandler[M[_]](implicit C: Capture[M])
+    extends ChannelM.Handler[ManagedChannelOps[M, ?]] {
 
   def newCall[I, O](
       methodDescriptor: MethodDescriptor[I, O],
-      callOptions: CallOptions): ManagedChannelOps[F, ClientCall[I, O]] =
+      callOptions: CallOptions): ManagedChannelOps[M, ClientCall[I, O]] =
     Kleisli(ch => C.capture(ch.newCall(methodDescriptor, callOptions)))
 
-  def authority: ManagedChannelOps[F, String] =
+  def authority: ManagedChannelOps[M, String] =
     Kleisli(ch => C.capture(ch.authority()))
 }

--- a/rpc/src/main/scala/client/handlers/ChannelMHandler.scala
+++ b/rpc/src/main/scala/client/handlers/ChannelMHandler.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc
+package client.handlers
+
+import cats.data.Kleisli
+import freestyle.Capture
+import freestyle.rpc.client.{ChannelM, ManagedChannelOps}
+import io.grpc.{CallOptions, ClientCall, MethodDescriptor}
+
+class ChannelMHandler[F[_]](implicit C: Capture[F])
+    extends ChannelM.Handler[ManagedChannelOps[F, ?]] {
+
+  def newCall[I, O](
+      methodDescriptor: MethodDescriptor[I, O],
+      callOptions: CallOptions): ManagedChannelOps[F, ClientCall[I, O]] =
+    Kleisli(ch => C.capture(ch.newCall(methodDescriptor, callOptions)))
+
+  def authority: ManagedChannelOps[F, String] =
+    Kleisli(ch => C.capture(ch.authority()))
+}

--- a/rpc/src/main/scala/client/handlers/ClientCallsMHandler.scala
+++ b/rpc/src/main/scala/client/handlers/ClientCallsMHandler.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc
+package client.handlers
+
+import freestyle.Capture
+import freestyle.async.AsyncContext
+import freestyle.rpc.client.ClientCallsM
+import io.grpc.{CallOptions, Channel, ClientCall, MethodDescriptor}
+import io.grpc.stub.{ClientCalls, StreamObserver}
+import freestyle.rpc.client.implicits._
+
+import scala.collection.JavaConverters._
+
+class ClientCallsMHandler[F[_]](implicit C: Capture[F], AC: AsyncContext[F])
+    extends ClientCallsM.Handler[F] {
+
+  def asyncUnaryCall[I, O](
+      call: ClientCall[I, O],
+      param: I,
+      observer: StreamObserver[O]): F[Unit] =
+    C.capture(ClientCalls.asyncUnaryCall(call, param, observer))
+
+  def asyncServerStreamingCall[I, O](
+      call: ClientCall[I, O],
+      param: I,
+      responseObserver: StreamObserver[O]): F[Unit] =
+    C.capture(ClientCalls.asyncServerStreamingCall(call, param, responseObserver))
+
+  def asyncClientStreamingCall[I, O](
+      call: ClientCall[I, O],
+      responseObserver: StreamObserver[O]): F[StreamObserver[I]] =
+    C.capture(ClientCalls.asyncClientStreamingCall(call, responseObserver))
+
+  def asyncBidiStreamingCall[I, O](
+      call: ClientCall[I, O],
+      responseObserver: StreamObserver[O]): F[StreamObserver[I]] =
+    C.capture(ClientCalls.asyncBidiStreamingCall(call, responseObserver))
+
+  def blockingUnaryCall[I, O](call: ClientCall[I, O], param: I): F[O] =
+    C.capture(ClientCalls.blockingUnaryCall(call, param))
+
+  def blockingUnaryCallChannel[I, O](
+      channel: Channel,
+      method: MethodDescriptor[I, O],
+      callOptions: CallOptions,
+      param: I): F[O] =
+    C.capture(ClientCalls.blockingUnaryCall(channel, method, callOptions, param))
+
+  def blockingServerStreamingCall[I, O](call: ClientCall[I, O], param: I): F[Iterator[O]] =
+    C.capture(ClientCalls.blockingServerStreamingCall(call, param).asScala)
+
+  def blockingServerStreamingCallChannel[I, O](
+      channel: Channel,
+      method: MethodDescriptor[I, O],
+      callOptions: CallOptions,
+      param: I): F[Iterator[O]] =
+    C.capture(ClientCalls.blockingServerStreamingCall(channel, method, callOptions, param).asScala)
+
+  def futureUnaryCall[I, O](call: ClientCall[I, O], param: I): F[O] =
+    listenableFuture2Async.apply(ClientCalls.futureUnaryCall(call, param))
+}

--- a/rpc/src/main/scala/client/handlers/ClientCallsMHandler.scala
+++ b/rpc/src/main/scala/client/handlers/ClientCallsMHandler.scala
@@ -26,51 +26,48 @@ import freestyle.rpc.client.implicits._
 
 import scala.collection.JavaConverters._
 
-class ClientCallsMHandler[F[_]](implicit C: Capture[F], AC: AsyncContext[F])
-    extends ClientCallsM.Handler[F] {
+class ClientCallsMHandler[M[_]](implicit C: Capture[M], AC: AsyncContext[M])
+    extends ClientCallsM.Handler[M] {
 
-  def asyncUnaryCall[I, O](
-      call: ClientCall[I, O],
-      param: I,
-      observer: StreamObserver[O]): F[Unit] =
+  def async[I, O](call: ClientCall[I, O], param: I, observer: StreamObserver[O]): M[Unit] =
     C.capture(ClientCalls.asyncUnaryCall(call, param, observer))
 
-  def asyncServerStreamingCall[I, O](
+  def asyncStreamServer[I, O](
       call: ClientCall[I, O],
       param: I,
-      responseObserver: StreamObserver[O]): F[Unit] =
+      responseObserver: StreamObserver[O]): M[Unit] =
     C.capture(ClientCalls.asyncServerStreamingCall(call, param, responseObserver))
 
-  def asyncClientStreamingCall[I, O](
+  def asyncStreamClient[I, O](
       call: ClientCall[I, O],
-      responseObserver: StreamObserver[O]): F[StreamObserver[I]] =
+      responseObserver: StreamObserver[O]): M[StreamObserver[I]] =
     C.capture(ClientCalls.asyncClientStreamingCall(call, responseObserver))
 
-  def asyncBidiStreamingCall[I, O](
+  def asyncStreamBidi[I, O](
       call: ClientCall[I, O],
-      responseObserver: StreamObserver[O]): F[StreamObserver[I]] =
+      responseObserver: StreamObserver[O]): M[StreamObserver[I]] =
     C.capture(ClientCalls.asyncBidiStreamingCall(call, responseObserver))
 
-  def blockingUnaryCall[I, O](call: ClientCall[I, O], param: I): F[O] =
+  def sync[I, O](call: ClientCall[I, O], param: I): M[O] =
     C.capture(ClientCalls.blockingUnaryCall(call, param))
 
-  def blockingUnaryCallChannel[I, O](
+  def syncC[I, O](
       channel: Channel,
       method: MethodDescriptor[I, O],
       callOptions: CallOptions,
-      param: I): F[O] =
+      param: I): M[O] =
     C.capture(ClientCalls.blockingUnaryCall(channel, method, callOptions, param))
 
-  def blockingServerStreamingCall[I, O](call: ClientCall[I, O], param: I): F[Iterator[O]] =
+  def syncStreamServer[I, O](call: ClientCall[I, O], param: I): M[Iterator[O]] =
     C.capture(ClientCalls.blockingServerStreamingCall(call, param).asScala)
 
-  def blockingServerStreamingCallChannel[I, O](
+  def syncStreamServerC[I, O](
       channel: Channel,
       method: MethodDescriptor[I, O],
       callOptions: CallOptions,
-      param: I): F[Iterator[O]] =
+      param: I): M[Iterator[O]] =
     C.capture(ClientCalls.blockingServerStreamingCall(channel, method, callOptions, param).asScala)
 
-  def futureUnaryCall[I, O](call: ClientCall[I, O], param: I): F[O] =
+  def asyncM[I, O](call: ClientCall[I, O], param: I): M[O] =
     listenableFuture2Async.apply(ClientCalls.futureUnaryCall(call, param))
 }

--- a/rpc/src/main/scala/client/implicits.scala
+++ b/rpc/src/main/scala/client/implicits.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc
+package client
+
+import cats.~>
+import com.google.common.util.concurrent._
+import freestyle._
+import freestyle.implicits._
+import freestyle.async.AsyncContext
+
+trait Conversions {
+
+  class ListenableFuture2AsyncM[F[_]](implicit AC: AsyncContext[F])
+      extends FSHandler[ListenableFuture, F] {
+    override def apply[A](fa: ListenableFuture[A]): F[A] =
+      AC.runAsync { cb =>
+        Futures.addCallback(fa, new FutureCallback[A] {
+          override def onSuccess(result: A): Unit = cb(Right(result))
+
+          override def onFailure(t: Throwable): Unit = cb(Left(t))
+        })
+      }
+  }
+
+  implicit def listenableFuture2Async[F[_]](implicit AC: AsyncContext[F]): ListenableFuture ~> F =
+    new ListenableFuture2AsyncM[F]
+}
+
+object implicits extends CaptureInstances with Conversions

--- a/rpc/src/main/scala/client/package.scala
+++ b/rpc/src/main/scala/client/package.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc
+
+import cats.data.Kleisli
+import cats.~>
+
+import scala.collection.JavaConverters._
+import io.grpc._
+
+package object client {
+
+  type ManagedChannelOps[F[_], A] = Kleisli[F, ManagedChannel, A]
+
+  class ManagedChannelInterpreter[F[_]](
+      initConfig: ManagedChannelFor,
+      configList: List[ManagedChannelConfig])
+      extends (Kleisli[F, ManagedChannel, ?] ~> F) {
+
+    private[this] def build(
+        initConfig: ManagedChannelFor,
+        configList: List[ManagedChannelConfig]): ManagedChannel = {
+      val builder: ManagedChannelBuilder[_] = initConfig match {
+        case ManagedChannelForAddress(name, port) => ManagedChannelBuilder.forAddress(name, port)
+        case ManagedChannelForTarget(target)      => ManagedChannelBuilder.forTarget(target)
+      }
+
+      configList
+        .foldLeft[ManagedChannelBuilder[_]](builder) { (acc, cfg) =>
+          (cfg match {
+            case DirectExecutor                     => acc.directExecutor()
+            case SetExecutor(executor)              => acc.executor(executor)
+            case AddInterceptorList(interceptors)   => acc.intercept(interceptors.asJava)
+            case AddInterceptor(interceptors @ _ *) => acc.intercept(interceptors: _*)
+            case UserAgent(userAgent)               => acc.userAgent(userAgent)
+            case OverrideAuthority(authority)       => acc.overrideAuthority(authority)
+            case UsePlaintext(skipNegotiation)      => acc.usePlaintext(skipNegotiation)
+            case NameResolverFactory(rf)            => acc.nameResolverFactory(rf)
+            case LoadBalancerFactory(lbf)           => acc.loadBalancerFactory(lbf)
+            case SetDecompressorRegistry(registry)  => acc.decompressorRegistry(registry)
+            case SetCompressorRegistry(registry)    => acc.compressorRegistry(registry)
+            case SetIdleTimeout(value, unit)        => acc.idleTimeout(value, unit)
+            case SetMaxInboundMessageSize(max)      => acc.maxInboundMessageSize(max)
+          }).asInstanceOf[ManagedChannelBuilder[_]]
+        }
+        .build()
+    }
+
+    override def apply[A](fa: Kleisli[F, ManagedChannel, A]): F[A] =
+      fa(build(initConfig, configList))
+  }
+}

--- a/rpc/src/main/scala/client/package.scala
+++ b/rpc/src/main/scala/client/package.scala
@@ -40,8 +40,8 @@ package object client {
       }
 
       configList
-        .foldLeft[ManagedChannelBuilder[_]](builder) { (acc, cfg) =>
-          (cfg match {
+        .foldLeft(builder) { (acc, cfg) =>
+          cfg match {
             case DirectExecutor                     => acc.directExecutor()
             case SetExecutor(executor)              => acc.executor(executor)
             case AddInterceptorList(interceptors)   => acc.intercept(interceptors.asJava)
@@ -55,7 +55,7 @@ package object client {
             case SetCompressorRegistry(registry)    => acc.compressorRegistry(registry)
             case SetIdleTimeout(value, unit)        => acc.idleTimeout(value, unit)
             case SetMaxInboundMessageSize(max)      => acc.maxInboundMessageSize(max)
-          }).asInstanceOf[ManagedChannelBuilder[_]]
+          }
         }
         .build()
     }

--- a/rpc/src/main/scala/server/GrpcConfig.scala
+++ b/rpc/src/main/scala/server/GrpcConfig.scala
@@ -24,24 +24,14 @@ import io.grpc._
 
 case class Config(port: Int)
 
-sealed trait GrpcConfig extends Product with Serializable
-
-case object DirectExecutor extends GrpcConfig
-
-case class SetExecutor(executor: Executor) extends GrpcConfig
-
-case class AddService(service: ServerServiceDefinition) extends GrpcConfig
-
-case class AddBindableService(bindableService: BindableService) extends GrpcConfig
-
-case class AddTransportFilter(filter: ServerTransportFilter) extends GrpcConfig
-
-case class AddStreamTracerFactory(factory: ServerStreamTracer.Factory) extends GrpcConfig
-
+sealed trait GrpcConfig                                                  extends Product with Serializable
+case object DirectExecutor                                               extends GrpcConfig
+case class SetExecutor(executor: Executor)                               extends GrpcConfig
+case class AddService(service: ServerServiceDefinition)                  extends GrpcConfig
+case class AddBindableService(bindableService: BindableService)          extends GrpcConfig
+case class AddTransportFilter(filter: ServerTransportFilter)             extends GrpcConfig
+case class AddStreamTracerFactory(factory: ServerStreamTracer.Factory)   extends GrpcConfig
 case class SetFallbackHandlerRegistry(fallbackRegistry: HandlerRegistry) extends GrpcConfig
-
-case class UseTransportSecurity(certChain: File, privateKey: File) extends GrpcConfig
-
-case class SetDecompressorRegistry(registry: DecompressorRegistry) extends GrpcConfig
-
-case class SetCompressorRegistry(registry: CompressorRegistry) extends GrpcConfig
+case class UseTransportSecurity(certChain: File, privateKey: File)       extends GrpcConfig
+case class SetDecompressorRegistry(registry: DecompressorRegistry)       extends GrpcConfig
+case class SetCompressorRegistry(registry: CompressorRegistry)           extends GrpcConfig

--- a/rpc/src/main/scala/server/implicits.scala
+++ b/rpc/src/main/scala/server/implicits.scala
@@ -29,8 +29,8 @@ trait Syntax {
 
   final class ServerOps(server: FreeS[GrpcServer.Op, Unit]) {
 
-    def bootstrapM[M[_]](implicit MM: Monad[M], handler: GrpcServer.Op ~> M): M[Unit] =
-      server.interpret[M]
+    def bootstrapM[F[_]](implicit M: Monad[F], handler: GrpcServer.Op ~> F): F[Unit] =
+      server.interpret[F]
 
     def bootstrapFuture(
         implicit MF: Monad[Future],

--- a/rpc/src/main/scala/server/implicits.scala
+++ b/rpc/src/main/scala/server/implicits.scala
@@ -29,8 +29,8 @@ trait Syntax {
 
   final class ServerOps(server: FreeS[GrpcServer.Op, Unit]) {
 
-    def bootstrapM[F[_]](implicit M: Monad[F], handler: GrpcServer.Op ~> F): F[Unit] =
-      server.interpret[F]
+    def bootstrapM[M[_]: Monad](implicit handler: GrpcServer.Op ~> M): M[Unit] =
+      server.interpret[M]
 
     def bootstrapFuture(
         implicit MF: Monad[Future],
@@ -42,7 +42,7 @@ trait Syntax {
 
 object implicits extends CaptureInstances with Syntax {
 
-  def server[F[_]](implicit app: GrpcServer[F]): FreeS[F, Unit] = {
+  def server[M[_]](implicit app: GrpcServer[M]): FreeS[M, Unit] = {
     for {
       _ <- app.start()
       _ <- app.awaitTermination()

--- a/rpc/src/main/scala/server/package.scala
+++ b/rpc/src/main/scala/server/package.scala
@@ -29,8 +29,8 @@ package object server {
 
     private[this] def build(configList: List[GrpcConfig]): Server =
       configList
-        .foldLeft[ServerBuilder[_]](ServerBuilder.forPort(initConfig.port))((acc, option) =>
-          (option match {
+        .foldLeft(ServerBuilder.forPort(initConfig.port))((acc, option) =>
+          option match {
             case DirectExecutor                  => acc.directExecutor()
             case SetExecutor(ex)                 => acc.executor(ex)
             case AddService(srv)                 => acc.addService(srv)
@@ -41,7 +41,7 @@ package object server {
             case UseTransportSecurity(cc, pk)    => acc.useTransportSecurity(cc, pk)
             case SetDecompressorRegistry(dr)     => acc.decompressorRegistry(dr)
             case SetCompressorRegistry(cr)       => acc.compressorRegistry(cr)
-          }).asInstanceOf[ServerBuilder[_]])
+        })
         .build()
 
     override def apply[B](fa: Kleisli[F, Server, B]): F[B] =


### PR DESCRIPTION
This PR solves partially the issue https://github.com/frees-io/freestyle-rpc/issues/11  (only unary services).

It brings some free algebras on top of Grpc for RPC clients. Concretely, it solves:

* Channel Configuration.
* Channel Algebra to be able to create new RPC calls, based on method descriptors and some call options.
* ClientCalls Algebra to perform the different types of calls (unary, client streaming, server streaming and bidirecctional).

It also updates the demo code to use these algebras, composing RPC services as freestyle modules:

```scala
@module
trait ClientAPP {
  val greetingClientM: GreetingClientM
  val echoClientM: EchoClientM
}

object GreetingClientApp {

  val messageRequest = MessageRequest("Freestyle")
  val echoRequest    = EchoRequest("echo...")

  def unaryDemo[F[_]](implicit APP: ClientAPP[F]): FreeS[F, (String, String, String)] = {

    val greetingClientM: GreetingClientM[F] = APP.greetingClientM
    val echoClientM: EchoClientM[F]         = APP.echoClientM

    val defaultOptions = CallOptions.DEFAULT

    for {
      hi   <- greetingClientM.sayHello(messageRequest, defaultOptions)
      bye  <- greetingClientM.sayGoodbye(messageRequest, defaultOptions)
      echo <- echoClientM.echo(echoRequest, defaultOptions)
    } yield {
      println(s"Received -> (${hi.message}, ${bye.message}, ${echo.message})")
      (hi.message, bye.message, echo.message)
    }
  }

  def runProgram[F[_]](implicit M: Monad[F]) = {

    Await.result(unaryDemo[ClientAPP.Op].interpret[Future], Duration.Inf)
  }
}
```