### PR TITLE
Adds additional server definitions tests

### DIFF
--- a/demo/greeting/src/main/scala/greeting/runtime/implicits.scala
+++ b/demo/greeting/src/main/scala/greeting/runtime/implicits.scala
@@ -23,11 +23,9 @@ import freestyle._
 import freestyle.implicits._
 import freestyle.async.implicits._
 import freestyle.config.implicits._
-import freestyle.rpc.client.ChannelConfig
 import freestyle.rpc.demo.echo.EchoServiceGrpc
 import freestyle.rpc.demo.greeting._
 import freestyle.rpc.demo.greeting.service._
-import io.grpc.Server
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
@@ -51,14 +49,14 @@ object server {
       AddService(EchoServiceGrpc.bindService(new EchoService, ec))
     )
 
-    val serverFromConfig: Server = Await.result(
+    val conf: ServerW = Await.result(
       BuildServerFromConfig[ServerConfig.Op]("rpc.server.port", grpcConfigs)
         .interpret[Future],
       1.seconds)
 
     implicit val grpcServerHandler: GrpcServer.Op ~> Future =
       new GrpcServerHandler[Future] andThen
-        new GrpcKInterpreter[Future](serverFromConfig)
+        new GrpcKInterpreter[Future](conf.server)
 
   }
 

--- a/demo/http/src/main/scala/user/runtime/implicits.scala
+++ b/demo/http/src/main/scala/user/runtime/implicits.scala
@@ -26,7 +26,6 @@ import freestyle.rpc.demo.user._
 import freestyle.rpc.server._
 import freestyle.rpc.server.implicits._
 import freestyle.rpc.server.handlers._
-import io.grpc.Server
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
@@ -39,13 +38,13 @@ object implicits {
     AddService(UserServiceGrpc.bindService(new UserService, ExecutionContext.global))
   )
 
-  val serverFromConfig: Server = Await.result(
+  val conf: ServerW = Await.result(
     BuildServerFromConfig[ServerConfig.Op]("rpc.server.port", grpcConfigs)
       .interpret[Future],
     1.seconds)
 
   implicit val grpcServerHandler: GrpcServer.Op ~> Future =
     new GrpcServerHandler[Future] andThen
-      new GrpcKInterpreter[Future](serverFromConfig)
+      new GrpcKInterpreter[Future](conf.server)
 
 }

--- a/demo/http/src/main/scala/user/runtime/implicits.scala
+++ b/demo/http/src/main/scala/user/runtime/implicits.scala
@@ -18,6 +18,7 @@ package freestyle.rpc.demo
 package user.runtime
 
 import cats.implicits._
+import cats.~>
 import freestyle._
 import freestyle.implicits._
 import freestyle.config.implicits._
@@ -25,6 +26,7 @@ import freestyle.rpc.demo.user._
 import freestyle.rpc.server._
 import freestyle.rpc.server.implicits._
 import freestyle.rpc.server.handlers._
+import io.grpc.Server
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
@@ -32,16 +34,18 @@ import scala.concurrent.{Await, ExecutionContext, Future}
 object implicits {
 
   implicit val ec: ExecutionContext = ExecutionContext.Implicits.global
-  val config: Config = Await.result(
-    ConfigForPort[ServerConfig.Op]("rpc.server.port")
-      .interpret[Future],
-    1.seconds)
 
   val grpcConfigs: List[GrpcConfig] = List(
     AddService(UserServiceGrpc.bindService(new UserService, ExecutionContext.global))
   )
 
-  implicit val grpcServerHandler =
-    new GrpcServerHandler[Future] andThen new GrpcConfigInterpreter[Future](config, grpcConfigs)
+  val serverFromConfig: Server = Await.result(
+    BuildServerFromConfig[ServerConfig.Op]("rpc.server.port", grpcConfigs)
+      .interpret[Future],
+    1.seconds)
+
+  implicit val grpcServerHandler: GrpcServer.Op ~> Future =
+    new GrpcServerHandler[Future] andThen
+      new GrpcKInterpreter[Future](serverFromConfig)
 
 }

--- a/rpc/src/main/scala/server/GrpcConfig.scala
+++ b/rpc/src/main/scala/server/GrpcConfig.scala
@@ -22,8 +22,6 @@ import java.util.concurrent.Executor
 
 import io.grpc._
 
-case class Config(port: Int)
-
 sealed trait GrpcConfig                                                  extends Product with Serializable
 case object DirectExecutor                                               extends GrpcConfig
 case class SetExecutor(executor: Executor)                               extends GrpcConfig
@@ -35,3 +33,29 @@ case class SetFallbackHandlerRegistry(fallbackRegistry: HandlerRegistry) extends
 case class UseTransportSecurity(certChain: File, privateKey: File)       extends GrpcConfig
 case class SetDecompressorRegistry(registry: DecompressorRegistry)       extends GrpcConfig
 case class SetCompressorRegistry(registry: CompressorRegistry)           extends GrpcConfig
+
+case class SServerBuilder(port: Int, grpcConfigList: List[GrpcConfig] = Nil) {
+
+  protected[this] lazy val sb: ServerBuilder[_ <: ServerBuilder[_]] = ServerBuilder.forPort(port)
+
+  def withGrpcConfigList(l: List[GrpcConfig]): SServerBuilder = this.copy(grpcConfigList = l)
+
+  def buildServer: Server = {
+    grpcConfigList
+      .foldLeft[ServerBuilder[_ <: ServerBuilder[_]]](sb)((acc, option) =>
+        option match {
+          case DirectExecutor                  => acc.directExecutor()
+          case SetExecutor(ex)                 => acc.executor(ex)
+          case AddService(srv)                 => acc.addService(srv)
+          case AddBindableService(srv)         => acc.addService(srv)
+          case AddTransportFilter(filter)      => acc.addTransportFilter(filter)
+          case AddStreamTracerFactory(factory) => acc.addStreamTracerFactory(factory)
+          case SetFallbackHandlerRegistry(fr)  => acc.fallbackHandlerRegistry(fr)
+          case UseTransportSecurity(cc, pk)    => acc.useTransportSecurity(cc, pk)
+          case SetDecompressorRegistry(dr)     => acc.decompressorRegistry(dr)
+          case SetCompressorRegistry(cr)       => acc.compressorRegistry(cr)
+      })
+      .build()
+  }
+
+}

--- a/rpc/src/main/scala/server/GrpcConfig.scala
+++ b/rpc/src/main/scala/server/GrpcConfig.scala
@@ -38,9 +38,7 @@ case class SServerBuilder(port: Int, grpcConfigList: List[GrpcConfig] = Nil) {
 
   protected[this] lazy val sb: ServerBuilder[_ <: ServerBuilder[_]] = ServerBuilder.forPort(port)
 
-  def withGrpcConfigList(l: List[GrpcConfig]): SServerBuilder = this.copy(grpcConfigList = l)
-
-  def buildServer: Server = {
+  def build: Server = {
     grpcConfigList
       .foldLeft[ServerBuilder[_ <: ServerBuilder[_]]](sb)((acc, option) =>
         option match {

--- a/rpc/src/main/scala/server/ServerConfig.scala
+++ b/rpc/src/main/scala/server/ServerConfig.scala
@@ -21,14 +21,16 @@ import cats.implicits._
 import freestyle._
 import freestyle.config.ConfigM
 import freestyle.config.implicits._
+import io.grpc.Server
 
 @module
 trait ServerConfig {
 
   val configM: ConfigM
 
-  val defaultPort = 50051
-
-  def loadConfigPort(portPath: String): FS.Seq[Config] =
-    configM.load map (config => Config(config.int(portPath).getOrElse(defaultPort)))
+  def buildServer(portPath: String, configList: List[GrpcConfig] = Nil): FS.Seq[Server] =
+    configM.load.map { config =>
+      val port = config.int(portPath).getOrElse(defaultPort)
+      SServerBuilder(port, configList).buildServer
+    }
 }

--- a/rpc/src/main/scala/server/ServerConfig.scala
+++ b/rpc/src/main/scala/server/ServerConfig.scala
@@ -23,14 +23,20 @@ import freestyle.config.ConfigM
 import freestyle.config.implicits._
 import io.grpc.Server
 
+case class ServerW(port: Int, configList: List[GrpcConfig]) {
+
+  lazy val server: Server = SServerBuilder(port, configList).build
+
+}
+
 @module
 trait ServerConfig {
 
   val configM: ConfigM
 
-  def buildServer(portPath: String, configList: List[GrpcConfig] = Nil): FS.Seq[Server] =
+  def buildServer(portPath: String, configList: List[GrpcConfig] = Nil): FS.Seq[ServerW] =
     configM.load.map { config =>
       val port = config.int(portPath).getOrElse(defaultPort)
-      SServerBuilder(port, configList).buildServer
+      ServerW(port, configList)
     }
 }

--- a/rpc/src/main/scala/server/package.scala
+++ b/rpc/src/main/scala/server/package.scala
@@ -35,6 +35,6 @@ package object server {
   }
 
   def BuildServerFromConfig[F[_]](portPath: String, configList: List[GrpcConfig] = Nil)(
-      implicit SC: ServerConfig[F]): FreeS[F, Server] =
+      implicit SC: ServerConfig[F]): FreeS[F, ServerW] =
     SC.buildServer(portPath, configList)
 }

--- a/rpc/src/main/scala/server/package.scala
+++ b/rpc/src/main/scala/server/package.scala
@@ -25,31 +25,16 @@ package object server {
 
   type GrpcServerOps[F[_], A] = Kleisli[F, Server, A]
 
-  class GrpcConfigInterpreter[F[_]](initConfig: Config, configList: List[GrpcConfig])
-      extends (Kleisli[F, Server, ?] ~> F) {
+  val defaultPort = 50051
 
-    private[this] def build(configList: List[GrpcConfig]): Server =
-      configList
-        .foldLeft(ServerBuilder.forPort(initConfig.port))((acc, option) =>
-          option match {
-            case DirectExecutor                  => acc.directExecutor()
-            case SetExecutor(ex)                 => acc.executor(ex)
-            case AddService(srv)                 => acc.addService(srv)
-            case AddBindableService(srv)         => acc.addService(srv)
-            case AddTransportFilter(filter)      => acc.addTransportFilter(filter)
-            case AddStreamTracerFactory(factory) => acc.addStreamTracerFactory(factory)
-            case SetFallbackHandlerRegistry(fr)  => acc.fallbackHandlerRegistry(fr)
-            case UseTransportSecurity(cc, pk)    => acc.useTransportSecurity(cc, pk)
-            case SetDecompressorRegistry(dr)     => acc.decompressorRegistry(dr)
-            case SetCompressorRegistry(cr)       => acc.compressorRegistry(cr)
-        })
-        .build()
+  class GrpcKInterpreter[F[_]](server: Server) extends (Kleisli[F, Server, ?] ~> F) {
 
     override def apply[B](fa: Kleisli[F, Server, B]): F[B] =
-      fa(build(configList))
+      fa(server)
 
   }
 
-  def ConfigForPort[F[_]](portPath: String)(implicit SC: ServerConfig[F]): FreeS[F, Config] =
-    SC.loadConfigPort(portPath)
+  def BuildServerFromConfig[F[_]](portPath: String, configList: List[GrpcConfig] = Nil)(
+      implicit SC: ServerConfig[F]): FreeS[F, Server] =
+    SC.buildServer(portPath, configList)
 }

--- a/rpc/src/test/resources/application.conf
+++ b/rpc/src/test/resources/application.conf
@@ -1,0 +1,12 @@
+rpc {
+  server {
+    port = 42
+  }
+}
+
+rpc {
+  client {
+    host = "localhost"
+    port = 42
+  }
+}

--- a/rpc/src/test/scala/server/RpcTestSuite.scala
+++ b/rpc/src/test/scala/server/RpcTestSuite.scala
@@ -67,6 +67,14 @@ trait RpcTestSuite extends WordSpec with Matchers with OneInstancePerTest with M
 
   object implicits extends DummyData {
 
+    implicit class FutureOps[A](f: Future[A]) {
+
+      def await: A = await(Duration.Inf)
+
+      def await(d: Duration): A = Await.result(f, d)
+
+    }
+
     def idApply[A](fa: GrpcServer.Op[A]): Id[A] = {
       import GrpcServer._
       fa match {

--- a/rpc/src/test/scala/server/RpcTestSuite.scala
+++ b/rpc/src/test/scala/server/RpcTestSuite.scala
@@ -67,21 +67,31 @@ trait RpcTestSuite extends WordSpec with Matchers with OneInstancePerTest with M
 
   object implicits extends DummyData {
 
-    implicit val grpcServerHandler: GrpcServer.Op ~> Id = new (GrpcServer.Op ~> Id) {
+    def idApply[A](fa: GrpcServer.Op[A]): Id[A] = {
       import GrpcServer._
-      override def apply[A](fa: GrpcServer.Op[A]): Id[A] = fa match {
-        case StartOP()                                => serverMock.start()
-        case GetPortOP()                              => serverMock.getPort
-        case GetServicesOP()                          => serverMock.getServices.asScala.toList
-        case GetImmutableServicesOP()                 => serverMock.getImmutableServices.asScala.toList
-        case GetMutableServicesOP()                   => serverMock.getMutableServices.asScala.toList
-        case ShutdownOP()                             => serverMock.shutdown()
-        case ShutdownNowOP()                          => serverMock.shutdownNow()
-        case IsShutdownOP()                           => serverMock.isShutdown
-        case IsTerminatedOP()                         => serverMock.isTerminated
-        case AwaitTerminationTimeoutOP(timeout, unit) => serverMock.awaitTermination(timeout, unit)
-        case AwaitTerminationOP()                     => serverMock.awaitTermination()
+      fa match {
+        case StartOP()                       => serverMock.start()
+        case GetPortOP()                     => serverMock.getPort
+        case GetServicesOP()                 => serverMock.getServices.asScala.toList
+        case GetImmutableServicesOP()        => serverMock.getImmutableServices.asScala.toList
+        case GetMutableServicesOP()          => serverMock.getMutableServices.asScala.toList
+        case ShutdownOP()                    => serverMock.shutdown()
+        case ShutdownNowOP()                 => serverMock.shutdownNow()
+        case IsShutdownOP()                  => serverMock.isShutdown
+        case IsTerminatedOP()                => serverMock.isTerminated
+        case AwaitTerminationTimeoutOP(t, u) => serverMock.awaitTermination(t, u)
+        case AwaitTerminationOP()            => serverMock.awaitTermination()
       }
     }
+
+    implicit val grpcServerHandlerId: GrpcServer.Op ~> Id =
+      new (GrpcServer.Op ~> Id) {
+        override def apply[A](fa: GrpcServer.Op[A]): Id[A] = idApply(fa)
+      }
+
+    implicit val grpcServerHandlerFuture: GrpcServer.Op ~> Future =
+      new (GrpcServer.Op ~> Future) {
+        override def apply[A](fa: GrpcServer.Op[A]): Future[A] = Future.successful(idApply(fa))
+      }
   }
 }

--- a/rpc/src/test/scala/server/ServerConfigTests.scala
+++ b/rpc/src/test/scala/server/ServerConfigTests.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc
+package server
+
+import cats.Id
+import cats.data.Kleisli
+import cats.implicits._
+import freestyle._
+import freestyle.implicits._
+import freestyle.config.implicits._
+import io.grpc.Server
+
+import scala.collection.JavaConverters._
+import scala.concurrent.{ExecutionContext, Future}
+
+class ServerConfigTests extends RpcTestSuite {
+
+  import implicits._
+
+  implicit val ec: ExecutionContext = ExecutionContext.Implicits.global
+
+  "ServerConfig.Op" should {
+
+    "load the port specified in the config file" in {
+
+      val serverF = BuildServerFromConfig[ServerConfig.Op]("rpc.server.port").interpret[Future]
+
+      serverF map (_.getPort shouldBe port)
+    }
+
+    "load the default port when the config port path is not found" in {
+
+      val serverF = BuildServerFromConfig[ServerConfig.Op]("rpc.wrong.path").interpret[Future]
+
+      serverF map (_.getPort shouldBe port)
+    }
+
+  }
+
+  "GrpcConfigInterpreter" should {
+
+    "work as expected" in {
+
+      val kInterpreter =
+        new GrpcKInterpreter[Id](serverMock).apply(Kleisli[Id, Server, Int](s => s.getPort))
+
+      kInterpreter shouldBe port
+    }
+
+  }
+
+  "SServerBuilder" should {
+
+    "work as expected" in {
+
+      val configList: List[GrpcConfig] = List(AddService(sd1))
+      val server: Server               = SServerBuilder(port).withGrpcConfigList(configList).buildServer
+
+      server.getServices.asScala shouldBe List(sd1)
+    }
+  }
+}

--- a/rpc/src/test/scala/server/ServerConfigTests.scala
+++ b/rpc/src/test/scala/server/ServerConfigTests.scala
@@ -38,16 +38,22 @@ class ServerConfigTests extends RpcTestSuite {
 
     "load the port specified in the config file" in {
 
-      val serverF = BuildServerFromConfig[ServerConfig.Op]("rpc.server.port").interpret[Future]
+      val serverConf: ServerW =
+        BuildServerFromConfig[ServerConfig.Op]("rpc.server.port")
+          .interpret[Future]
+          .await
 
-      serverF map (_.getPort shouldBe port)
+      serverConf.port shouldBe port
     }
 
     "load the default port when the config port path is not found" in {
 
-      val serverF = BuildServerFromConfig[ServerConfig.Op]("rpc.wrong.path").interpret[Future]
+      val serverConf: ServerW =
+        BuildServerFromConfig[ServerConfig.Op]("rpc.wrong.path")
+          .interpret[Future]
+          .await
 
-      serverF map (_.getPort shouldBe port)
+      serverConf.port shouldBe defaultPort
     }
 
   }
@@ -69,9 +75,9 @@ class ServerConfigTests extends RpcTestSuite {
     "work as expected" in {
 
       val configList: List[GrpcConfig] = List(AddService(sd1))
-      val server: Server               = SServerBuilder(port).withGrpcConfigList(configList).buildServer
+      val server: Server               = SServerBuilder(port, configList).build
 
-      server.getServices.asScala shouldBe List(sd1)
+      server.getServices.asScala.toList shouldBe List(sd1)
     }
   }
 }

--- a/rpc/src/test/scala/server/SyntaxTests.scala
+++ b/rpc/src/test/scala/server/SyntaxTests.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc
+package server
+
+import cats.Id
+import cats.implicits._
+import freestyle.rpc.server.implicits._
+
+import scala.concurrent.ExecutionContext
+
+class SyntaxTests extends RpcTestSuite {
+
+  import implicits._
+
+  implicit val ec: ExecutionContext = ExecutionContext.Implicits.global
+
+  "server syntax" should {
+
+    "allow using bootstrapM" in {
+
+      server[GrpcServer.Op].bootstrapM[Id] shouldBe ((): Unit)
+
+      (serverMock.start _).verify().once()
+      (serverMock.awaitTermination _).verify().once()
+    }
+
+    "allow using bootstrapFuture" in {
+
+      server[GrpcServer.Op].bootstrapFuture.map { f =>
+        f shouldBe ((): Unit)
+
+        (serverMock.start _).verify().once()
+        (serverMock.awaitTermination _).verify().once()
+      }
+    }
+
+  }
+
+}


### PR DESCRIPTION
This PR completes https://github.com/frees-io/freestyle-rpc/issues/15

Now, rpc server module reaches almost the 100% of test coverage. In the next PRs I'll cover the client definition tests.

Please, @fedefernandez could you take a look? Thanks!