### PR TITLE
@service Macro

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,12 +16,14 @@ lazy val rpc = project
   .settings(moduleName := "freestyle-rpc")
   .settings(
     Seq(
+      resolvers += Resolver.bintrayRepo("beyondthelines", "maven"),
       libraryDependencies ++= commonDeps ++ freestyleCoreDeps() ++
         Seq(
           %%("freestyle-async"),
           %%("freestyle-config"),
           %%("scalameta-contrib"),
           "io.grpc"                % "grpc-all" % "1.4.0",
+          "beyondthelines"         %% "pbdirect" % "0.0.3",
           %%("scalamockScalatest") % "test"
         )
     ): _*

--- a/demo/protocolgen/src/main/proto/service.proto
+++ b/demo/protocolgen/src/main/proto/service.proto
@@ -21,4 +21,4 @@ service GreetingService {
    rpc bidiHello (stream MessageReply) returns (stream MessageRequest) {}
 }
            
-                        
+           

--- a/demo/protocolgen/src/main/scala/Client.scala
+++ b/demo/protocolgen/src/main/scala/Client.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc
+package demo
+package protocolgen
+
+import freestyle.rpc.demo.protocolgen.protocols._
+import _root_.io.grpc._
+
+object Client {
+
+  trait GreetingServiceBlockingClient {
+    def sayHello(request: MessageRequest): MessageReply
+  }
+
+  class GreetingServiceStub(channel: Channel, options: CallOptions = CallOptions.DEFAULT)
+      extends stub.AbstractStub[GreetingServiceStub](channel, options) {
+
+    def sayHello(request: MessageRequest): scala.concurrent.Future[MessageReply] =
+      com.trueaccord.scalapb.grpc.Grpc.guavaFuture2ScalaFuture(
+        stub.ClientCalls
+          .futureUnaryCall(
+            channel.newCall(GreetingService.sayHelloMethodDescriptor, options),
+            request))
+
+    override def build(channel: Channel, options: CallOptions): GreetingServiceStub =
+      new GreetingServiceStub(channel, options)
+  }
+
+  def clientStub(channel: Channel): GreetingServiceStub = new GreetingServiceStub(channel)
+
+}

--- a/demo/protocolgen/src/main/scala/ClientApp.scala
+++ b/demo/protocolgen/src/main/scala/ClientApp.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc
+package demo
+package protocolgen
+
+import freestyle.rpc.demo.protocolgen.protocols._
+import io.grpc._
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+object ClientApp {
+
+  def main(args: Array[String]): Unit = {
+
+    val channel = ManagedChannelBuilder.forAddress("localhost", 50051).usePlaintext(true).build
+
+    val asyncHelloClient: Client.GreetingServiceStub = Client.clientStub(channel)
+
+    Await.result(asyncHelloClient.sayHello(MessageRequest("hi", None)), Duration.Inf)
+
+    (): Unit
+  }
+}

--- a/demo/protocolgen/src/main/scala/ClientApp.scala
+++ b/demo/protocolgen/src/main/scala/ClientApp.scala
@@ -32,7 +32,8 @@ object ClientApp {
 
     val asyncHelloClient: Client.GreetingServiceStub = Client.clientStub(channel)
 
-    Await.result(asyncHelloClient.sayHello(MessageRequest("hi", None)), Duration.Inf)
+    val result = Await.result(asyncHelloClient.sayHello(MessageRequest("hi", None)), Duration.Inf)
+    println(result)
 
     (): Unit
   }

--- a/demo/protocolgen/src/main/scala/ServerApp.scala
+++ b/demo/protocolgen/src/main/scala/ServerApp.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc
+package demo
+package protocolgen
+
+import cats.implicits._
+import freestyle.rpc.server.GrpcServer
+import freestyle.rpc.server.implicits._
+import freestyle.rpc.demo.protocolgen.runtime.server.implicits._
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+object ServerApp {
+
+  def main(args: Array[String]): Unit =
+    Await.result(server[GrpcServer.Op].bootstrapFuture, Duration.Inf)
+
+}

--- a/demo/protocolgen/src/main/scala/runtime/implicits.scala
+++ b/demo/protocolgen/src/main/scala/runtime/implicits.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc
+package demo
+package protocolgen
+package runtime
+
+import cats.~>
+import freestyle.rpc.demo.protocolgen.protocols.GreetingService
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait CommonImplicits {
+
+  implicit val ec: ExecutionContext = ExecutionContext.Implicits.global
+
+}
+
+object server {
+
+  trait Implicits extends CommonImplicits {
+
+    import freestyle.rpc.server._
+    import freestyle.rpc.server.handlers._
+    import freestyle.rpc.server.implicits._
+
+    val grpcConfigs: List[GrpcConfig] = List(
+      AddService(GreetingService.bindService)
+    )
+
+    val conf: ServerW = ServerW(50051, grpcConfigs)
+
+    implicit val grpcServerHandler: GrpcServer.Op ~> Future =
+      new GrpcServerHandler[Future] andThen
+        new GrpcKInterpreter[Future](conf.server)
+
+  }
+
+  object implicits extends Implicits
+
+}

--- a/demo/protocolgen/src/main/scala/service.scala
+++ b/demo/protocolgen/src/main/scala/service.scala
@@ -45,12 +45,11 @@ object protocols {
 
     @rpc
     @stream[RequestStreaming.type]
-    def lotsOfGreetings(
-        @stream msg: StreamObserver[MessageReply]): FS[StreamObserver[MessageRequest]]
+    def lotsOfGreetings(msg: StreamObserver[MessageReply]): FS[StreamObserver[MessageRequest]]
 
     @rpc
     @stream[BidirectionalStreaming.type]
-    def bidiHello(@stream msg: StreamObserver[MessageReply]): FS[StreamObserver[MessageRequest]]
+    def bidiHello(msg: StreamObserver[MessageReply]): FS[StreamObserver[MessageRequest]]
   }
 
 }

--- a/demo/protocolgen/src/main/scala/service.scala
+++ b/demo/protocolgen/src/main/scala/service.scala
@@ -35,6 +35,7 @@ object protocols {
 
   @free
   @service
+  @debug
   trait GreetingService {
 
     @rpc def sayHello(msg: MessageRequest): FS[MessageReply]

--- a/demo/protocolgen/src/main/scala/service.scala
+++ b/demo/protocolgen/src/main/scala/service.scala
@@ -19,7 +19,6 @@ package rpc
 package demo
 package protocolgen
 
-import freestyle.internal.EffectLike
 import freestyle.rpc.protocol._
 import io.grpc.stub.StreamObserver
 
@@ -34,8 +33,9 @@ object protocols {
   @message
   case class MessageReply(name: String, n: List[Int])
 
+  @free
   @service
-  trait GreetingService[F[_]] extends EffectLike[F] {
+  trait GreetingService {
 
     @rpc def sayHello(msg: MessageRequest): FS[MessageReply]
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -32,7 +32,13 @@ object ProjectPlugin extends AutoPlugin {
         addCommandAlias(
           "runClient",
           ";project demo-greeting;runMain freestyle.rpc.demo.greeting.GreetingClientApp") ++
-        addCommandAlias("validateHttpDemo", ";project demo-http;clean;compile;test")
+        addCommandAlias("validateHttpDemo", ";project demo-http;clean;compile;test") ++
+        addCommandAlias(
+          "runS",
+          ";project demo-protocolgen;runMain freestyle.rpc.demo.protocolgen.ServerApp") ++
+        addCommandAlias(
+          "runC",
+          ";project demo-protocolgen;runMain freestyle.rpc.demo.protocolgen.ClientApp")
 
     lazy val GOPATH = Option(sys.props("go.path")).getOrElse("/your/go/path")
 

--- a/rpc/src/main/scala/ProtoCodeGen.scala
+++ b/rpc/src/main/scala/ProtoCodeGen.scala
@@ -39,9 +39,8 @@ object ProtoCodeGen {
             Files.write(
               file.toPath,
               contents
-                .mkString("\n\n")
                 .getBytes(Charset.forName("UTF-8")),
-              StandardOpenOption.CREATE_NEW
+              StandardOpenOption.CREATE
             )
         }; ()
       case _ =>

--- a/rpc/src/main/scala/internal/service/GRPCServiceDefBuilder.scala
+++ b/rpc/src/main/scala/internal/service/GRPCServiceDefBuilder.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc.internal.service
+
+import io.grpc.{
+  MethodDescriptor,
+  ServerCallHandler,
+  ServerMethodDefinition,
+  ServerServiceDefinition
+}
+
+class GRPCServiceDefBuilder[Req, Res] {
+  def apply(
+      name: String,
+      calls: (MethodDescriptor[Req, Res], ServerCallHandler[Req, Res])*): ServerServiceDefinition = {
+    val builder = io.grpc.ServerServiceDefinition.builder(name)
+    calls
+      .foldLeft(builder) {
+        case (b, (descriptor, call)) =>
+          b.addMethod(ServerMethodDefinition.create(descriptor, call))
+      }
+      .build()
+  }
+}

--- a/rpc/src/main/scala/internal/service/GRPCServiceDefBuilder.scala
+++ b/rpc/src/main/scala/internal/service/GRPCServiceDefBuilder.scala
@@ -23,15 +23,18 @@ import io.grpc.{
   ServerServiceDefinition
 }
 
-class GRPCServiceDefBuilder[Req, Res] {
-  def apply(
-      name: String,
-      calls: (MethodDescriptor[Req, Res], ServerCallHandler[Req, Res])*): ServerServiceDefinition = {
+class GRPCServiceDefBuilder(
+    name: String,
+    calls: (MethodDescriptor[_, _], ServerCallHandler[_, _])*) {
+  def apply: ServerServiceDefinition = {
     val builder = io.grpc.ServerServiceDefinition.builder(name)
     calls
       .foldLeft(builder) {
         case (b, (descriptor, call)) =>
-          b.addMethod(ServerMethodDefinition.create(descriptor, call))
+          b.addMethod(
+            ServerMethodDefinition.create(
+              descriptor.asInstanceOf[MethodDescriptor[Any, Any]],
+              call.asInstanceOf[ServerCallHandler[Any, Any]]))
       }
       .build()
   }

--- a/rpc/src/main/scala/internal/service/StreamingMethods.scala
+++ b/rpc/src/main/scala/internal/service/StreamingMethods.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle
+package rpc
+package internal
+package service
+
+import cats.implicits._
+import cats.{Comonad, Monad, MonadError}
+import io.grpc.stub.ServerCalls.{
+  BidiStreamingMethod,
+  ClientStreamingMethod,
+  ServerStreamingMethod,
+  UnaryMethod
+}
+import io.grpc.stub.StreamObserver
+import io.grpc.{Status, StatusException}
+
+object calls {
+
+  private[this] def completeObserver[A](observer: StreamObserver[A])(
+      t: Either[Throwable, A]): Unit = t match {
+    case Right(value) =>
+      observer.onNext(value)
+      observer.onCompleted()
+    case Left(s: StatusException) =>
+      observer.onError(s)
+    case Left(e) =>
+      observer.onError(
+        Status.INTERNAL.withDescription(e.getMessage).withCause(e).asException()
+      )
+  }
+
+  def unaryMethod[F[_], M[_], Req, Res](f: (Req) => FreeS[F, Res])(
+      implicit ME: MonadError[M, Throwable],
+      H: FSHandler[F, M]): UnaryMethod[Req, Res] = new UnaryMethod[Req, Res] {
+    override def invoke(request: Req, responseObserver: StreamObserver[Res]): Unit = {
+      val result = f(request).interpret[M]
+      ME.attempt(result).map(completeObserver(responseObserver))
+    }
+  }
+
+  def clientStreamingMethod[F[_], M[_], Req, Res](
+      f: (StreamObserver[Res]) => FreeS[F, StreamObserver[Req]])(
+      implicit ME: MonadError[M, Throwable],
+      C: Comonad[M],
+      H: FSHandler[F, M]): ClientStreamingMethod[Req, Res] = new ClientStreamingMethod[Req, Res] {
+    override def invoke(responseObserver: StreamObserver[Res]): StreamObserver[Req] =
+      C.extract(f(responseObserver).interpret[M])
+  }
+
+  def serverStreamingMethod[F[_], M[_], Req, Res](f: (Req, StreamObserver[Res]) => FreeS[F, Unit])(
+      implicit ME: MonadError[M, Throwable],
+      H: FSHandler[F, M]): ServerStreamingMethod[Req, Res] = new ServerStreamingMethod[Req, Res] {
+    override def invoke(request: Req, responseObserver: StreamObserver[Res]): Unit =
+      f(request, responseObserver).interpret[M]
+  }
+
+  def bidiStreamingMethod[F[_], M[_], Req, Res](
+      f: (StreamObserver[Res]) => FreeS[F, StreamObserver[Req]])(
+      implicit ME: MonadError[M, Throwable],
+      C: Comonad[M],
+      H: FSHandler[F, M]): BidiStreamingMethod[Req, Res] = new BidiStreamingMethod[Req, Res] {
+    override def invoke(responseObserver: StreamObserver[Res]): StreamObserver[Req] =
+      C.extract(f(responseObserver).interpret[M])
+  }
+
+}

--- a/rpc/src/main/scala/internal/service/service.scala
+++ b/rpc/src/main/scala/internal/service/service.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc.internal.service
+
+import freestyle.internal.ScalametaUtil
+
+import scala.collection.immutable.Seq
+import scala.meta.Defn.{Class, Object, Trait}
+import scala.meta._
+import scala.meta.contrib._
+
+// $COVERAGE-OFF$ScalaJS + coverage = fails with NoClassDef exceptions
+object serviceImpl {
+
+  import errors._
+
+  def service(defn: Any): Stat = defn match {
+
+    case Term.Block(Seq(cls: Trait, companion: Object)) =>
+      serviceExtras(cls, companion)
+    case Term.Block(Seq(cls: Class, companion: Object)) if ScalametaUtil.isAbstract(cls) =>
+      serviceExtras(cls, companion)
+    case _ =>
+      println(defn.getClass)
+      abort(s"$invalid. $abstractOnly")
+  }
+
+  def serviceExtras(alg: Defn, companion: Object): Term.Block =
+    Term.Block(Seq(alg, enrich(companion)))
+
+  def enrich(companion: Object): Object = companion match {
+    case q"..$mods object $ename extends $template" =>
+      template match {
+        case template"{ ..$earlyInit } with ..$inits { $self => ..$stats }" =>
+          val enrichedTemplate =
+            template"{ ..$earlyInit } with ..$inits { $self => ..${enrich(stats)} }"
+          val result = q"..$mods object $ename extends $enrichedTemplate"
+          println(result)
+          result
+      }
+  }
+
+  def enrich(members: Seq[Stat]): Seq[Stat] =
+    members :+ q"trait ServiceHandler[F[_]] extends Handler[({type L[A] = _root_.freestyle.FreeS[F, A]})#L]"
+
+}
+
+private[internal] object errors {
+  // Messages of error
+  val invalid = "Invalid use of `@service`"
+  val abstractOnly =
+    "`@service` can only annotate a trait or abstract class already annotated with @free"
+  val onlyReqs =
+    "In a `@service`-trait (or class), all abstract methods declarations should be of type FS[_] and annotated with @rpc"
+  val nonEmpty =
+    "A `@service` trait or class must have at least one abstract method of type `FS[_]`"
+}
+// $COVERAGE-ON$

--- a/rpc/src/main/scala/proto/annotations.scala
+++ b/rpc/src/main/scala/proto/annotations.scala
@@ -17,11 +17,18 @@
 package freestyle
 package rpc
 
-import scala.annotation.StaticAnnotation
+import freestyle.rpc.internal.service.serviceImpl
+
+import scala.annotation.{compileTimeOnly, StaticAnnotation}
 
 package object protocol {
 
-  class service extends StaticAnnotation
+  @compileTimeOnly("enable macro paradise to expand @free macro annotations")
+  class service extends StaticAnnotation {
+    import scala.meta._
+
+    inline def apply(defn: Any): Any = meta { serviceImpl.service(defn) }
+  }
 
   class rpc extends StaticAnnotation
 

--- a/rpc/src/main/scala/proto/converters.scala
+++ b/rpc/src/main/scala/proto/converters.scala
@@ -125,20 +125,20 @@ object converters {
           ProtoService(
             name = t.name.value,
             rpcs = t.collect {
-              case q"@rpc @stream[ResponseStreaming] def $name[..$tparams]($request, observer: StreamObserver[$response]): FS[Unit]" =>
+              case q"@rpc @stream[ResponseStreaming.type] def $name[..$tparams]($request, observer: StreamObserver[$response]): FS[Unit]" =>
                 ProtoServiceField(
                   name = name.value,
                   request = extractParamType(request),
                   response = response.toString(),
                   streamingType = Some(ResponseStreaming))
-              case q"@rpc @stream[RequestStreaming] def $name[..$tparams]($param): FS[StreamObserver[$response]]" =>
+              case q"@rpc @stream[RequestStreaming.type] def $name[..$tparams]($param): FS[StreamObserver[$response]]" =>
                 ProtoServiceField(
                   name = name.value,
                   request = extractParamStreamingType(param),
                   response = response.toString(),
                   streamingType = Some(RequestStreaming)
                 )
-              case q"@rpc @stream[BidirectionalStreaming] def $name[..$tparams]($param): FS[StreamObserver[$response]]" =>
+              case q"@rpc @stream[BidirectionalStreaming.type] def $name[..$tparams]($param): FS[StreamObserver[$response]]" =>
                 ProtoServiceField(
                   name = name.value,
                   request = extractParamStreamingType(param),


### PR DESCRIPTION
Fixes #29 

Generates valid service description for a @free annotated macro with the proto annotations.
```scala
@free
  @service
  @debug
  trait GreetingService {

    @rpc def sayHello(msg: MessageRequest): FS[MessageReply]

    @rpc
    @stream[ResponseStreaming.type]
    def lotsOfReplies(msg: MessageRequest, observer: StreamObserver[MessageReply]): FS[Unit]

    @rpc
    @stream[RequestStreaming.type]
    def lotsOfGreetings(msg: StreamObserver[MessageReply]): FS[StreamObserver[MessageRequest]]

    @rpc
    @stream[BidirectionalStreaming.type]
    def bidiHello(msg: StreamObserver[MessageReply]): FS[StreamObserver[MessageRequest]]
  }
```
Allows you to:
```scala
def grpcConfigs[M[_]](implicit ME: MonadError[M, Throwable]): List[GrpcConfig] = List(
      AddService(GreetingService.bindService[GreetingService.Op, M])
)
```
