### PR TITLE
Upgrades gRPC. Releases frees-rpc 0.0.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,27 @@
 
 Simple RPC with Freestyle
 
-# Demo
+## Installation
+
+Add the following dependency to your project's build file.
+
+For Scala 2.11.x and 2.12.x:
+
+[comment]: # (Start Replace)
+
+```scala
+"io.frees" %% "frees-rpc" % "0.0.1"
+```
+
+Or, if using Scala.js (0.6.x):
+
+```scala
+"io.frees" %%% "frees-rpc" % "0.0.1"
+```
+
+[comment]: # (End Replace)
+
+## Demo
 
 See [freestyle-rpc-examples repo](https://github.com/frees-io/freestyle-rpc-examples).
 

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ lazy val rpc = project
           %%("freestyle-async"),
           %%("freestyle-config"),
           %%("scalameta-contrib"),
-          "io.grpc"        % "grpc-all"  % "1.4.0",
+          "io.grpc"        % "grpc-all"  % "1.6.1",
           "beyondthelines" %% "pbdirect" % "0.0.3",
           %%("monix"),
           %%("scalamockScalatest") % "test"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.1-SNAPSHOT"
+version in ThisBuild := "0.0.1"


### PR DESCRIPTION
Fixes https://github.com/frees-io/freestyle-rpc/issues/38

It also releases the first release (0.0.1) of `freestyle-rpc` giving some tiny instructions about how to use it.