### PR TITLE
Bug Fix  Proto Code Generator for Custom Types

### DIFF
--- a/rpc/src/main/scala/proto/converters.scala
+++ b/rpc/src/main/scala/proto/converters.scala
@@ -108,8 +108,12 @@ object converters {
             convert(param"..$mods $paramname: $tpe = $expropt", tag, Some(Repeated))
           case param"..$mods $paramname: Option[$tpe] = $expropt" =>
             convert(param"..$mods $paramname: $tpe = $expropt", tag, None)
-          case param"..$mods $paramname: $tpe = $expropt" =>
-            ProtoCustomType(name = paramname.value, tag = tag, id = tpe.toString())
+          case param"..$mods $paramname: $tpe = $expr" =>
+            val ntpe = tpe match {
+              case Some(tt) => tt.toString
+              case _        => tpe.toString
+            }
+            ProtoCustomType(name = paramname.value, tag = tag, id = ntpe)
         }
       }
   }


### PR DESCRIPTION
`Type.Arg` within the input parameters are optional (`Option[scala.meta.Type.Arg]`). Hence, `toString` method was printing the file with the existential type. For example:

```
message CustomType2 {
   string foo = 1;
   Some(CustomType1) bar = 2;
}
```

This fix comes to solve it, making the output as follows:

```
message CustomType2 {
   string foo = 1;
   CustomType1 bar = 2;
}
```