### PR TITLE
Fixes proto code generator for repeated types

### DIFF
--- a/rpc/src/main/scala/proto/converters.scala
+++ b/rpc/src/main/scala/proto/converters.scala
@@ -113,7 +113,7 @@ object converters {
               case Some(tt) => tt.toString
               case _        => tpe.toString
             }
-            ProtoCustomType(name = paramname.value, tag = tag, id = ntpe)
+            ProtoCustomType(mod = mod, name = paramname.value, tag = tag, id = ntpe)
         }
       }
   }


### PR DESCRIPTION
This PR fixes list types as `repeated` (for custom types) in the generated proto files.

```scala
case class Foo(bar: List[CustomType])
```

Results as:

```
message Foo {
   repeated CustomType bar = 1;
}
```