### PR TITLE
Makes the ChannelBuilder build a public method

### DIFF
--- a/rpc/src/main/scala/client/package.scala
+++ b/rpc/src/main/scala/client/package.scala
@@ -32,7 +32,7 @@ package object client {
       configList: List[ManagedChannelConfig])
       extends (Kleisli[F, ManagedChannel, ?] ~> F) {
 
-    private[this] def build(
+    def build(
         initConfig: ManagedChannelFor,
         configList: List[ManagedChannelConfig]): ManagedChannel = {
       val builder: ManagedChannelBuilder[_] = initConfig match {


### PR DESCRIPTION
This PR removes the unnecessary `private` modifier for the `Channel` build method.

@vejeta ^^