### PR TITLE
Fixes Client Streaming rpc server

### DIFF
--- a/rpc/src/main/scala/internal/service/service.scala
+++ b/rpc/src/main/scala/internal/service/service.scala
@@ -101,7 +101,7 @@ case class ServiceAlg(defn: Defn) {
   val serviceBindings: Defn.Def = {
     val args: Seq[Term.Tuple] = requests.map(_.call)
     q"""
-       def bindService[F[_], M[_]](implicit algebra: $algName[F], handler: _root_.freestyle.FSHandler[F, M], ME: _root_.cats.MonadError[M, Throwable], C: _root_.cats.Comonad[M], S: _root_.monix.execution.Scheduler): _root_.io.grpc.ServerServiceDefinition =
+       def bindService[F[_], M[_]](implicit algebra: $algName[F], HTask: _root_.freestyle.FSHandler[M, _root_.monix.eval.Task], handler: _root_.freestyle.FSHandler[F, M], ME: _root_.cats.MonadError[M, Throwable], C: _root_.cats.Comonad[M], S: _root_.monix.execution.Scheduler): _root_.io.grpc.ServerServiceDefinition =
            new freestyle.rpc.internal.service.GRPCServiceDefBuilder(${Lit.String(algName.value)}, ..$args).apply
      """
   }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.3-SNAPSHOT"
+version in ThisBuild := "0.0.3"


### PR DESCRIPTION
Regarding the `ClientStreaming` mode, this PR replaces the `Comonad` implicit dependency by a simple Natural Transformation to go from `M` to `Task`, since it's the more simplest way to create the `Transformer` function, which actually is a:

```scala
/** A `Transformer` is a function used for transforming observables */
type Transformer[-A,+B] = Observable[A] => Observable[B]
```

