### PR TITLE
Upgrades to sbt 1.0.1 and Scala 2.12.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: required
 
 scala:
 - 2.11.11
-- 2.12.2
+- 2.12.3
 
 jdk:
 - oraclejdk8

--- a/build.sbt
+++ b/build.sbt
@@ -8,18 +8,16 @@ lazy val rpc = project
   .settings(scalaMetaSettings: _*)
   .settings(
     Seq(
-      resolvers += Resolver.bintrayRepo("beyondthelines", "maven"),
       libraryDependencies ++= commonDeps ++ freestyleCoreDeps() ++
         Seq(
+          %("grpc-all"),
           %%("freestyle-async"),
           %%("freestyle-config"),
           %%("freestyle-logging"),
-          %%("scalameta-contrib"),
-          "io.grpc"        % "grpc-all"  % "1.6.1",
-          "beyondthelines" %% "pbdirect" % "0.0.3",
+          %%("scalameta-contrib", "1.8.0"),
+          %%("pbdirect"),
           %%("monix"),
           %%("scalamockScalatest") % "test"
-        ),
-      coverageExcludedPackages := "<empty>;freestyle\\.rpc\\.demo\\..*"
+        )
     ): _*
   )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version = 1.0.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("io.frees" % "sbt-freestyle" % "0.1.2")
+addSbtPlugin("io.frees" % "sbt-freestyle" % "0.2.4")

--- a/rpc/src/main/scala/client/package.scala
+++ b/rpc/src/main/scala/client/package.scala
@@ -43,19 +43,19 @@ package object client {
       configList
         .foldLeft(builder) { (acc, cfg) =>
           cfg match {
-            case DirectExecutor                     => acc.directExecutor()
-            case SetExecutor(executor)              => acc.executor(executor)
-            case AddInterceptorList(interceptors)   => acc.intercept(interceptors.asJava)
-            case AddInterceptor(interceptors @ _ *) => acc.intercept(interceptors: _*)
-            case UserAgent(userAgent)               => acc.userAgent(userAgent)
-            case OverrideAuthority(authority)       => acc.overrideAuthority(authority)
-            case UsePlaintext(skipNegotiation)      => acc.usePlaintext(skipNegotiation)
-            case NameResolverFactory(rf)            => acc.nameResolverFactory(rf)
-            case LoadBalancerFactory(lbf)           => acc.loadBalancerFactory(lbf)
-            case SetDecompressorRegistry(registry)  => acc.decompressorRegistry(registry)
-            case SetCompressorRegistry(registry)    => acc.compressorRegistry(registry)
-            case SetIdleTimeout(value, unit)        => acc.idleTimeout(value, unit)
-            case SetMaxInboundMessageSize(max)      => acc.maxInboundMessageSize(max)
+            case DirectExecutor                    => acc.directExecutor()
+            case SetExecutor(executor)             => acc.executor(executor)
+            case AddInterceptorList(interceptors)  => acc.intercept(interceptors.asJava)
+            case AddInterceptor(interceptors @ _*) => acc.intercept(interceptors: _*)
+            case UserAgent(userAgent)              => acc.userAgent(userAgent)
+            case OverrideAuthority(authority)      => acc.overrideAuthority(authority)
+            case UsePlaintext(skipNegotiation)     => acc.usePlaintext(skipNegotiation)
+            case NameResolverFactory(rf)           => acc.nameResolverFactory(rf)
+            case LoadBalancerFactory(lbf)          => acc.loadBalancerFactory(lbf)
+            case SetDecompressorRegistry(registry) => acc.decompressorRegistry(registry)
+            case SetCompressorRegistry(registry)   => acc.compressorRegistry(registry)
+            case SetIdleTimeout(value, unit)       => acc.idleTimeout(value, unit)
+            case SetMaxInboundMessageSize(max)     => acc.maxInboundMessageSize(max)
           }
         }
         .build()

--- a/rpc/src/test/scala/client/RpcClientTestSuite.scala
+++ b/rpc/src/test/scala/client/RpcClientTestSuite.scala
@@ -19,11 +19,7 @@ package client
 
 import java.util.concurrent.{Callable, Executors}
 
-import com.google.common.util.concurrent.{
-  ListenableFuture,
-  ListeningExecutorService,
-  MoreExecutors
-}
+import com.google.common.util.concurrent.{ListenableFuture, ListeningExecutorService, MoreExecutors}
 import freestyle.rpc.client.utils.StringMarshaller
 import io.grpc.{ClientCall, ManagedChannel, MethodDescriptor}
 


### PR DESCRIPTION
It also updates the `build.sbt` in order to use entirely the `sbt-org-policies` DSL to inject dependencies.