### PR TITLE
Test Coverage for some client definitions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,13 @@ pgpPassphrase := Some(getEnvVar("PGP_PASSPHRASE").getOrElse("").toCharArray)
 pgpPublicRing := file(s"$gpgFolder/pubring.gpg")
 pgpSecretRing := file(s"$gpgFolder/secring.gpg")
 
+lazy val root = project
+  .in(file("."))
+  .settings(name := "freestyle-rpc")
+  .settings(noPublishSettings)
+  .dependsOn(common, rpc)
+  .aggregate(common, rpc)
+
 lazy val common = project
   .in(file("common"))
   .settings(moduleName := "frees-rpc-common")

--- a/rpc/src/main/scala/internal/service/service.scala
+++ b/rpc/src/main/scala/internal/service/service.scala
@@ -32,6 +32,7 @@ import scala.meta.Defn.{Class, Object, Trait}
 import scala.meta._
 import _root_.io.grpc.MethodDescriptor.Marshaller
 
+// $COVERAGE-OFF$
 object serviceImpl {
 
   import errors._
@@ -237,3 +238,5 @@ object encoders {
     }
 
 }
+
+// $COVERAGE-ON$

--- a/rpc/src/main/scala/proto/annotations.scala
+++ b/rpc/src/main/scala/proto/annotations.scala
@@ -21,6 +21,7 @@ import freestyle.rpc.internal.service.serviceImpl
 
 import scala.annotation.{compileTimeOnly, StaticAnnotation}
 
+// $COVERAGE-OFF$
 package object protocol {
 
   @compileTimeOnly("enable macro paradise to expand @free macro annotations")
@@ -38,3 +39,5 @@ package object protocol {
 
   class option(val name: String, val value: String, val quote: Boolean) extends StaticAnnotation
 }
+
+// $COVERAGE-ON$

--- a/rpc/src/test/scala/client/ImplicitTests.scala
+++ b/rpc/src/test/scala/client/ImplicitTests.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc
+package client
+
+import freestyle.FSHandler
+import monix.eval.Task
+
+import scala.concurrent.Future
+
+class ImplicitTests extends RpcClientTestSuite {
+
+  type FSHandlerTask2Future = FSHandler[Task, Future]
+
+  "FutureInstances.task2Future" should {
+
+    "provide an implicit evidence allowing to transform from monix.eval.Task to scala.concurrent.Future" in {
+
+      implicit val S: monix.execution.Scheduler = monix.execution.Scheduler.Implicits.global
+      import freestyle.async.implicits.futureAsyncContext
+
+      freestyle.rpc.client.implicits.task2Future shouldBe a[FSHandlerTask2Future]
+    }
+
+    "fail compiling when the monix.execution.Scheduler implicit evidence is not present" in {
+
+      shapeless.test.illTyped(
+        """freestyle.rpc.client.implicits.task2Future""",
+        ".*could not find implicit value for parameter AC.*"
+      )
+    }
+
+    "fail compiling when the freestyle.async.AsyncContext implicit evidence is not present" in {
+
+      implicit val S: monix.execution.Scheduler = monix.execution.Scheduler.Implicits.global
+
+      shapeless.test.illTyped(
+        """freestyle.rpc.client.implicits.task2Future""",
+        ".*could not find implicit value for parameter AC.*"
+      )
+    }
+
+  }
+
+}

--- a/rpc/src/test/scala/client/RpcClientTestSuite.scala
+++ b/rpc/src/test/scala/client/RpcClientTestSuite.scala
@@ -40,8 +40,9 @@ trait RpcClientTestSuite extends RpcBaseTestSuite {
       new StringMarshaller()
     )
 
-    val authority: String = "localhost:8696"
-    val foo               = "Bar"
+    val authority: String      = "localhost:8696"
+    val foo                    = "Bar"
+    val failureMessage: String = "❗"
 
   }
 

--- a/rpc/src/test/scala/client/handlers/TaskMHandlerTests.scala
+++ b/rpc/src/test/scala/client/handlers/TaskMHandlerTests.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc
+package client.handlers
+
+import cats.~>
+import freestyle.rpc.client.RpcClientTestSuite
+import freestyle.rpc.client.implicits._
+import monix.eval.Task
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future}
+
+class TaskMHandlerTests extends RpcClientTestSuite {
+
+  import implicits._
+
+  "TaskMHandler" should {
+
+    "transform monix.eval.Task into any effect F, if an implicit evidence of " +
+      "freestyle.async.AsyncContext[F] is provided" in {
+
+      implicit val S: monix.execution.Scheduler = monix.execution.Scheduler.Implicits.global
+      import freestyle.async.implicits.futureAsyncContext
+
+      val handler: Task ~> Future = task2Future
+      val fooTask: Task[String]   = Task.now(foo)
+
+      Await.result(handler(fooTask), Duration.Inf) shouldBe foo
+    }
+
+    "recover from a failed monix.eval.Task wrapping them into scala.concurrent.Future" in {
+
+      implicit val S: monix.execution.Scheduler = monix.execution.Scheduler.Implicits.global
+      import freestyle.async.implicits.futureAsyncContext
+
+      val handler: Task ~> Future  = task2Future
+      val taskFailed: Task[String] = Task.raiseError(new RuntimeException(failureMessage))
+
+      Await.result(handler(taskFailed) recover {
+        case _ => failureMessage
+      }, Duration.Inf) shouldBe failureMessage
+    }
+
+  }
+
+}


### PR DESCRIPTION
Partially solves https://github.com/frees-io/freestyle-rpc/issues/24

It disables coverage for macros and annotations.