### PR TITLE
Groups async implicits into AsyncInstances trait

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,12 +43,12 @@ lazy val rpc = project
           %%("frees-config"),
           %%("frees-logging"),
           %("grpc-all"),
-          %("grpc-testing"),
           %%("monix"),
           %%("pbdirect"),
           %%("scalameta-contrib", "1.8.0"),
-          %%("scalatest")          % "test",
-          %%("scalamockScalatest") % "test"
+          %("grpc-testing")        % Test,
+          %%("scalatest")          % Test,
+          %%("scalamockScalatest") % Test
         )
     ): _*
   )

--- a/rpc/src/main/scala/AsyncInstances.scala
+++ b/rpc/src/main/scala/AsyncInstances.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle
+package rpc
+
+import cats.{~>, Comonad}
+import freestyle.async.AsyncContext
+import freestyle.rpc.client.handlers._
+import journal.Logger
+import monix.eval.Task
+import monix.execution.Scheduler
+
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.duration._
+
+trait AsyncInstances {
+
+  protected[this] val asyncLogger: Logger            = Logger[this.type]
+  protected[this] val atMostDuration: FiniteDuration = 10.seconds
+
+  implicit def futureComonad(implicit ec: ExecutionContext): Comonad[Future] =
+    new Comonad[Future] {
+      def extract[A](x: Future[A]): A = {
+        asyncLogger.info(s"${Thread.currentThread().getName} Waiting $atMostDuration for $x...")
+        Await.result(x, atMostDuration)
+      }
+
+      override def coflatMap[A, B](fa: Future[A])(f: (Future[A]) => B): Future[B] = Future(f(fa))
+
+      override def map[A, B](fa: Future[A])(f: (A) => B): Future[B] =
+        fa.map(f)
+    }
+
+  implicit def task2Future(
+      implicit AC: AsyncContext[Future],
+      S: Scheduler): FSHandler[Task, Future] =
+    new TaskMHandler[Future]
+
+  implicit val future2Task: Future ~> Task =
+    new (Future ~> Task) {
+      override def apply[A](fa: Future[A]): Task[A] = {
+        asyncLogger.info(s"${Thread.currentThread().getName} Deferring Future to Task...")
+        Task.deferFuture(fa)
+      }
+    }
+
+  implicit val task2Task: Task ~> Task = new (Task ~> Task) {
+    override def apply[A](fa: Task[A]): Task[A] = fa
+  }
+
+}

--- a/rpc/src/main/scala/client/implicits.scala
+++ b/rpc/src/main/scala/client/implicits.scala
@@ -18,20 +18,4 @@ package freestyle
 package rpc
 package client
 
-import freestyle.async.AsyncContext
-import freestyle.rpc.client.handlers._
-import monix.eval.Task
-import monix.execution.Scheduler
-
-import scala.concurrent.Future
-
-trait FutureInstances {
-
-  implicit def task2Future(
-      implicit AC: AsyncContext[Future],
-      S: Scheduler): FSHandler[Task, Future] =
-    new TaskMHandler[Future]
-
-}
-
-object implicits extends CaptureInstances with FutureInstances
+object implicits extends CaptureInstances with AsyncInstances

--- a/rpc/src/main/scala/server/implicits.scala
+++ b/rpc/src/main/scala/server/implicits.scala
@@ -63,4 +63,9 @@ trait Helpers {
 
 }
 
-object implicits extends CaptureInstances with Syntax with Helpers
+object implicits
+    extends CaptureInstances
+    with AsyncInstances
+    with Syntax
+    with Helpers
+    with freestyle.loggingJVM.Implicits

--- a/rpc/src/test/scala/Utils.scala
+++ b/rpc/src/test/scala/Utils.scala
@@ -249,42 +249,21 @@ object Utils {
 
   }
 
-  trait FreesRuntime extends freestyle.rpc.client.FutureInstances {
+  trait FreesRuntime {
 
     import service._
     import helpers._
     import handlers.server._
     import handlers.client._
-    import clientProgram._
     import cats.implicits._
     import freestyle.implicits._
     import freestyle.async.implicits._
-    import freestyle.loggingJVM.implicits._
     import freestyle.rpc.server._
     import freestyle.rpc.server.implicits._
     import freestyle.rpc.server.handlers._
 
     implicit val ec: ExecutionContext         = ExecutionContext.Implicits.global
     implicit val S: monix.execution.Scheduler = monix.execution.Scheduler.Implicits.global
-
-    protected val atMostDuration: FiniteDuration = 10.seconds
-
-    implicit def futureComonad(implicit ec: ExecutionContext): Comonad[Future] =
-      new Comonad[Future] {
-        def extract[A](x: Future[A]): A =
-          Await.result(x, atMostDuration)
-
-        override def coflatMap[A, B](fa: Future[A])(f: (Future[A]) => B): Future[B] = Future(f(fa))
-
-        override def map[A, B](fa: Future[A])(f: (A) => B): Future[B] =
-          fa.map(f)
-      }
-
-    implicit val future2Task: Future ~> Task =
-      new (Future ~> Task) {
-        override def apply[A](fa: Future[A]): Task[A] =
-          Task.deferFuture(fa)
-      }
 
     //////////////////////////////////
     // Server Runtime Configuration //

--- a/rpc/src/test/scala/client/ImplicitTests.scala
+++ b/rpc/src/test/scala/client/ImplicitTests.scala
@@ -26,7 +26,7 @@ class ImplicitTests extends RpcClientTestSuite {
 
   type FSHandlerTask2Future = FSHandler[Task, Future]
 
-  "FutureInstances.task2Future" should {
+  "AsyncInstances.task2Future" should {
 
     "provide an implicit evidence allowing to transform from monix.eval.Task to scala.concurrent.Future" in {
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.2-SNAPSHOT"
+version in ThisBuild := "0.1.2"


### PR DESCRIPTION
This PR groups the set of async common instances (`Future`, `Task`) into the `AsyncInstances` trait. Then these implicits are provided for both `server` and `client` implicit imports:

`import freestyle.rpc.server.implicits._` or `import freestyle.rpc.client.implicits._`.

Fixes #70 
Fixes #66 