### PR TITLE
Provides Empty Message

### DIFF
--- a/rpc/src/main/scala/proto/annotations.scala
+++ b/rpc/src/main/scala/proto/annotations.scala
@@ -38,6 +38,9 @@ package object protocol {
   class message extends StaticAnnotation
 
   class option(val name: String, val value: String, val quote: Boolean) extends StaticAnnotation
+
+  @message
+  case class Empty()
 }
 
 // $COVERAGE-ON$

--- a/rpc/src/test/scala/FreesRPCTests.scala
+++ b/rpc/src/test/scala/FreesRPCTests.scala
@@ -20,6 +20,7 @@ import freestyle._
 import org.scalatest._
 import freestyle.rpc.server.GrpcServerApp
 import freestyle.rpc.Utils.clientProgram.MyRPCClient
+import freestyle.rpc.protocol.Empty
 
 class FreesRPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
 
@@ -117,6 +118,15 @@ class FreesRPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
         APP.notAllowed(true)
 
       clientProgram[MyRPCClient.Op].runF shouldBe c1
+
+    }
+
+    "be able to invoke services with empty requests" in {
+
+      def clientProgram[M[_]](implicit APP: MyRPCClient[M]): FreeS[M, Empty] =
+        APP.empty
+
+      clientProgram[MyRPCClient.Op].runF shouldBe Empty()
 
     }
 


### PR DESCRIPTION
As Protobuf provides [Emtpy](https://github.com/google/protobuf/blob/master/src/google/protobuf/empty.proto), this PR provides an empty type: `freestyle.rpc.protocol.Empty` as generic empty message that you can re-use to avoid defining duplicated empty messages in your APIs. A typical example is to use it as the request or the response type of an API method.

For instance:

```scala
@free
@service
trait Foo {      
  @rpc def Bar(empty: Empty): FS[Empty]      
}
```

Fixes #63 