### PR TITLE
Support for Avro Serialization

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,6 +45,7 @@ lazy val rpc = project
           %("grpc-all", "1.7.0"),
           %%("monix"),
           %%("pbdirect"),
+          "com.sksamuel.avro4s" %% "avro4s-core" % "1.8.0",
           %%("scalameta-contrib", "1.8.0"),
           %("grpc-testing")        % Test,
           %%("scalatest")          % Test,

--- a/common/src/main/scala/protocol.scala
+++ b/common/src/main/scala/protocol.scala
@@ -22,3 +22,7 @@ sealed trait StreamingType         extends Product with Serializable
 case object RequestStreaming       extends StreamingType
 case object ResponseStreaming      extends StreamingType
 case object BidirectionalStreaming extends StreamingType
+
+sealed trait SerializationType extends Product with Serializable
+case object Protobuf           extends SerializationType
+case object Avro               extends SerializationType

--- a/rpc/src/main/scala/proto/annotations.scala
+++ b/rpc/src/main/scala/proto/annotations.scala
@@ -31,7 +31,7 @@ package object protocol {
     inline def apply(defn: Any): Any = meta { serviceImpl.service(defn) }
   }
 
-  class rpc extends StaticAnnotation
+  class rpc(val serializationType: SerializationType) extends StaticAnnotation
 
   class stream[S <: StreamingType] extends StaticAnnotation
 

--- a/rpc/src/test/scala/Utils.scala
+++ b/rpc/src/test/scala/Utils.scala
@@ -52,21 +52,21 @@ object Utils {
     @service
     trait FreesRPCService {
 
-      @rpc def notAllowed(b: Boolean): FS[C]
+      @rpc(Avro) def notAllowed(b: Boolean): FS[C]
 
-      @rpc def empty(empty: Empty): FS[Empty]
+      @rpc(Protobuf) def empty(empty: Empty): FS[Empty]
 
-      @rpc def unary(a: A): FS[C]
+      @rpc(Avro) def unary(a: A): FS[C]
 
-      @rpc
+      @rpc(Protobuf)
       @stream[ResponseStreaming.type]
       def serverStreaming(b: B): FS[Observable[C]]
 
-      @rpc
+      @rpc(Protobuf)
       @stream[RequestStreaming.type]
       def clientStreaming(oa: Observable[A]): FS[D]
 
-      @rpc
+      @rpc(Protobuf)
       @stream[BidirectionalStreaming.type]
       def biStreaming(oe: Observable[E]): FS[Observable[E]]
     }

--- a/rpc/src/test/scala/Utils.scala
+++ b/rpc/src/test/scala/Utils.scala
@@ -52,7 +52,7 @@ object Utils {
     @service
     trait FreesRPCService {
 
-      @rpc(Avro) def notAllowed(b: Boolean): FS[C]
+      @rpc(Protobuf) def notAllowed(b: Boolean): FS[C]
 
       @rpc(Protobuf) def empty(empty: Empty): FS[Empty]
 
@@ -66,7 +66,7 @@ object Utils {
       @stream[RequestStreaming.type]
       def clientStreaming(oa: Observable[A]): FS[D]
 
-      @rpc(Protobuf)
+      @rpc(Avro)
       @stream[BidirectionalStreaming.type]
       def biStreaming(oe: Observable[E]): FS[Observable[E]]
     }

--- a/rpc/src/test/scala/server/GrpcServerTests.scala
+++ b/rpc/src/test/scala/server/GrpcServerTests.scala
@@ -63,7 +63,7 @@ class GrpcServerTests extends RpcServerTestSuite {
         val k = awaitTerminationTimeout(timeout, timeoutUnit)
         val l = awaitTermination()
 
-        (a |@| b |@| c |@| d |@| e |@| f |@| g |@| h |@| i |@| j |@| k |@| l).tupled
+        (a, b, c, d, e, f, g, h, i, j, k, l).tupled
       }
 
       program[GrpcServer.Op].interpret[Id] shouldBe ((


### PR DESCRIPTION
This PR brings support for Avro serialization.

Therefore, from now on, you can choose for your service (at `@rpc` level) the type of serialization. Currently: `Avro` or `Protobuf`.

```scala
@free
    @service
    trait FreesRPCService {

      @rpc(Avro) def unary(a: A): FS[C]

      @rpc(Protobuf)
      @stream[ResponseStreaming.type]
      def serverStreaming(b: B): FS[Observable[C]]

      @rpc(Protobuf)
      @stream[RequestStreaming.type]
      def clientStreaming(oa: Observable[A]): FS[D]

      @rpc(Avro)
      @stream[BidirectionalStreaming.type]
      def biStreaming(oe: Observable[E]): FS[Observable[E]]
    }
```

We are relying on [avro4s](https://github.com/sksamuel/avro4s) for the binary serialization/deserialization.