### PR TITLE
Async Implicits provided by frees-rpc Implicits

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,6 +28,8 @@ lazy val common = project
   .settings(moduleName := "frees-rpc-common")
   .settings(scalacOptions := Seq("-deprecation", "-encoding", "UTF-8", "-feature", "-unchecked"))
 
+lazy val freesV = "0.4.2"
+
 lazy val rpc = project
   .in(file("rpc"))
   .dependsOn(common)
@@ -37,11 +39,11 @@ lazy val rpc = project
     Seq(
       libraryDependencies ++= commonDeps ++
         Seq(
-          %%("frees-core"),
-          %%("frees-async"),
-          %%("frees-async-guava"),
-          %%("frees-config"),
-          %%("frees-logging"),
+          %%("frees-core", freesV),
+          %%("frees-async", freesV),
+          %%("frees-async-guava", freesV),
+          %%("frees-config", freesV),
+          %%("frees-logging", freesV),
           %("grpc-all", "1.7.0"),
           %%("monix"),
           %%("pbdirect"),

--- a/rpc/src/main/scala/RPCAsyncImplicits.scala
+++ b/rpc/src/main/scala/RPCAsyncImplicits.scala
@@ -28,7 +28,7 @@ import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration._
 
-trait AsyncInstances {
+trait RPCAsyncImplicits extends freestyle.async.Implicits {
 
   protected[this] val asyncLogger: Logger            = Logger[this.type]
   protected[this] val atMostDuration: FiniteDuration = 10.seconds

--- a/rpc/src/main/scala/RPCAsyncImplicits.scala
+++ b/rpc/src/main/scala/RPCAsyncImplicits.scala
@@ -46,9 +46,7 @@ trait RPCAsyncImplicits extends freestyle.async.Implicits {
         fa.map(f)
     }
 
-  implicit def task2Future(
-      implicit AC: AsyncContext[Future],
-      S: Scheduler): FSHandler[Task, Future] =
+  implicit def task2Future(implicit S: Scheduler): FSHandler[Task, Future] =
     new TaskMHandler[Future]
 
   implicit val future2Task: Future ~> Task =

--- a/rpc/src/main/scala/client/implicits.scala
+++ b/rpc/src/main/scala/client/implicits.scala
@@ -18,4 +18,8 @@ package freestyle
 package rpc
 package client
 
-object implicits extends CaptureInstances with RPCAsyncImplicits
+object implicits
+    extends CaptureInstances
+    with freestyle.Interpreters
+    with freestyle.FreeSInstances
+    with RPCAsyncImplicits

--- a/rpc/src/main/scala/client/implicits.scala
+++ b/rpc/src/main/scala/client/implicits.scala
@@ -18,4 +18,4 @@ package freestyle
 package rpc
 package client
 
-object implicits extends CaptureInstances with AsyncInstances
+object implicits extends CaptureInstances with RPCAsyncImplicits

--- a/rpc/src/main/scala/server/implicits.scala
+++ b/rpc/src/main/scala/server/implicits.scala
@@ -68,4 +68,6 @@ object implicits
     with RPCAsyncImplicits
     with Syntax
     with Helpers
+    with freestyle.Interpreters
+    with freestyle.FreeSInstances
     with freestyle.loggingJVM.Implicits

--- a/rpc/src/main/scala/server/implicits.scala
+++ b/rpc/src/main/scala/server/implicits.scala
@@ -65,7 +65,7 @@ trait Helpers {
 
 object implicits
     extends CaptureInstances
-    with AsyncInstances
+    with RPCAsyncImplicits
     with Syntax
     with Helpers
     with freestyle.loggingJVM.Implicits

--- a/rpc/src/test/scala/FreesRPCTests.scala
+++ b/rpc/src/test/scala/FreesRPCTests.scala
@@ -25,20 +25,24 @@ import freestyle.rpc.protocol.Empty
 class FreesRPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
 
   import cats.implicits._
-  import freestyle.implicits._
-  import freestyle.loggingJVM.implicits._
   import freestyle.rpc.Utils.service._
   import freestyle.rpc.Utils.database._
   import freestyle.rpc.Utils.helpers._
   import freestyle.rpc.Utils.implicits._
 
-  override protected def beforeAll(): Unit =
+  override protected def beforeAll(): Unit = {
+    import freestyle.rpc.server.implicits._
     serverStart[GrpcServerApp.Op].runF
+  }
 
-  override protected def afterAll(): Unit =
+  override protected def afterAll(): Unit = {
+    import freestyle.rpc.server.implicits._
     serverStop[GrpcServerApp.Op].runF
+  }
 
   "frees-rpc server" should {
+
+    import freestyle.rpc.server.implicits._
 
     "allow to startup a server and check if it's alive" in {
 
@@ -61,6 +65,8 @@ class FreesRPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
   }
 
   "frees-rpc client" should {
+
+    import freestyle.rpc.client.implicits._
 
     "be able to run unary services" in {
 

--- a/rpc/src/test/scala/Utils.scala
+++ b/rpc/src/test/scala/Utils.scala
@@ -268,8 +268,6 @@ object Utils {
     import handlers.server._
     import handlers.client._
     import cats.implicits._
-    import freestyle.implicits._
-    import freestyle.async.implicits._
     import freestyle.rpc.server._
     import freestyle.rpc.server.implicits._
     import freestyle.rpc.server.handlers._

--- a/rpc/src/test/scala/client/ImplicitTests.scala
+++ b/rpc/src/test/scala/client/ImplicitTests.scala
@@ -31,7 +31,6 @@ class ImplicitTests extends RpcClientTestSuite {
     "provide an implicit evidence allowing to transform from monix.eval.Task to scala.concurrent.Future" in {
 
       implicit val S: monix.execution.Scheduler = monix.execution.Scheduler.Implicits.global
-      import freestyle.async.implicits.futureAsyncContext
 
       freestyle.rpc.client.implicits.task2Future shouldBe a[FSHandlerTask2Future]
     }
@@ -40,17 +39,7 @@ class ImplicitTests extends RpcClientTestSuite {
 
       shapeless.test.illTyped(
         """freestyle.rpc.client.implicits.task2Future""",
-        ".*could not find implicit value for parameter AC.*"
-      )
-    }
-
-    "fail compiling when the freestyle.async.AsyncContext implicit evidence is not present" in {
-
-      implicit val S: monix.execution.Scheduler = monix.execution.Scheduler.Implicits.global
-
-      shapeless.test.illTyped(
-        """freestyle.rpc.client.implicits.task2Future""",
-        ".*could not find implicit value for parameter AC.*"
+        ".*Cannot find an implicit Scheduler, either import monix.execution.Scheduler.Implicits.global or use a custom one.*"
       )
     }
 


### PR DESCRIPTION
In order to simplify the use of `frees-rpc`, this PR makes that server and client implicits provide automatically:

* `import freestyle.implicits._`
* `import freestyle.async.implicits._`

Hence, users only need to import either:

* `import freestyle.rpc.client.implicits._`
* `import freestyle.rpc.server.implicits._`
