### PR TITLE
Builds the marshallers explicitly for method descriptors

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.1-SNAPSHOT"
+version in ThisBuild := "0.3.0-SNAPSHOT"


### PR DESCRIPTION
Instead of requiring the marshallers implicitly, this PR is proposing to create them explicitly, when the method descriptors are being created.