### PR TITLE
Releases 0.3.0

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.1-SNAPSHOT"
+version in ThisBuild := "0.3.0"


### PR DESCRIPTION
It includes breaking features, given that from now on, the `@rpc` annotation requires the type of serialization (either `Protobuf` or `Avro`).