### PR TITLE
Upgrades frees-rpc to Freestyle 0.4.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ jdk:
 - oraclejdk8
 
 scala:
-- 2.11.11
-- 2.12.3
+- 2.11.12
+- 2.12.4
 
 
 before_cache:

--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ lazy val rpc = project
           %%("frees-tagless", freesV),
           %("grpc-all", "1.7.0"),
           %%("monix"),
-          %%("pbdirect"),
+          %%("pbdirect", "0.0.7"),
           "com.sksamuel.avro4s" %% "avro4s-core" % "1.8.0",
           %%("scalameta-contrib", "1.8.0"),
           %("grpc-testing")        % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ lazy val common = project
   .settings(moduleName := "frees-rpc-common")
   .settings(scalacOptions := Seq("-deprecation", "-encoding", "UTF-8", "-feature", "-unchecked"))
 
-lazy val freesV = "0.4.4"
+lazy val freesV = "0.4.6"
 
 lazy val rpc = project
   .in(file("rpc"))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.0.3
+sbt.version = 1.0.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
 resolvers += Resolver.sonatypeRepo("releases")
-addSbtPlugin("io.frees" % "sbt-freestyle" % "0.3.7")
+addSbtPlugin("io.frees" % "sbt-freestyle" % "0.3.13")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.5-SNAPSHOT"
+version in ThisBuild := "0.4.0"


### PR DESCRIPTION
It also releases a new minor version: `0.4.0`, since we are releasing the new features done by @tbrown1979 in this PR https://github.com/frees-io/freestyle-rpc/pull/92 .