### PR TITLE
Server Endpoints and Effect Monad

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,6 +42,7 @@ lazy val rpc = project
           %%("frees-core", freesV),
           %%("frees-async", freesV),
           %%("frees-async-guava", freesV),
+          %%("frees-async-cats-effect", freesV),
           %%("frees-config", freesV),
           %%("frees-logging", freesV),
           %%("frees-tagless", freesV),

--- a/rpc/src/main/scala/RPCAsyncImplicits.scala
+++ b/rpc/src/main/scala/RPCAsyncImplicits.scala
@@ -31,7 +31,7 @@ import scala.concurrent.duration._
 trait IOCapture {
 
   implicit val ioCapture: Capture[IO] = new Capture[IO] {
-    override def capture[A](a: => A): IO[A] = IO.pure(a)
+    override def capture[A](a: => A): IO[A] = IO(a)
   }
 
 }

--- a/rpc/src/main/scala/RPCAsyncImplicits.scala
+++ b/rpc/src/main/scala/RPCAsyncImplicits.scala
@@ -17,6 +17,7 @@
 package freestyle
 package rpc
 
+import cats.effect.IO
 import cats.{~>, Comonad}
 import freestyle.rpc.client.handlers._
 import journal.Logger
@@ -27,10 +28,22 @@ import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration._
 
-trait RPCAsyncImplicits extends freestyle.async.Implicits {
+trait IOCapture {
+
+  implicit val ioCapture: Capture[IO] = new Capture[IO] {
+    override def capture[A](a: => A): IO[A] = IO.pure(a)
+  }
+
+}
+
+trait BaseAsync extends freestyle.async.Implicits {
 
   protected[this] val asyncLogger: Logger            = Logger[this.type]
   protected[this] val atMostDuration: FiniteDuration = 10.seconds
+
+}
+
+trait FutureAsyncInstances extends BaseAsync {
 
   implicit def futureComonad(implicit EC: ExecutionContext): Comonad[Future] =
     new Comonad[Future] {
@@ -45,6 +58,18 @@ trait RPCAsyncImplicits extends freestyle.async.Implicits {
         fa.map(f)
     }
 
+  implicit val future2Task: Future ~> Task =
+    new (Future ~> Task) {
+      override def apply[A](fa: Future[A]): Task[A] = {
+        asyncLogger.info(s"${Thread.currentThread().getName} Deferring Future to Task...")
+        Task.deferFuture(fa)
+      }
+    }
+
+}
+
+trait TaskAsyncInstances extends BaseAsync {
+
   implicit def taskComonad(implicit S: Scheduler): Comonad[Task] =
     new Comonad[Task] {
       def extract[A](x: Task[A]): A = {
@@ -58,19 +83,32 @@ trait RPCAsyncImplicits extends freestyle.async.Implicits {
         fa.map(f)
     }
 
-  implicit def task2Future(implicit S: Scheduler): FSHandler[Task, Future] =
+  implicit def task2Future(implicit S: Scheduler): Task ~> Future =
     new TaskMHandler[Future]
-
-  implicit val future2Task: Future ~> Task =
-    new (Future ~> Task) {
-      override def apply[A](fa: Future[A]): Task[A] = {
-        asyncLogger.info(s"${Thread.currentThread().getName} Deferring Future to Task...")
-        Task.deferFuture(fa)
-      }
-    }
 
   implicit val task2Task: Task ~> Task = new (Task ~> Task) {
     override def apply[A](fa: Task[A]): Task[A] = fa
   }
 
+  implicit def task2IO(implicit S: Scheduler): Task ~> IO = new (Task ~> IO) {
+    override def apply[A](fa: Task[A]): IO[A] = fa.toIO
+  }
 }
+
+trait IOAsyncInstances extends BaseAsync {
+
+  implicit val ioComonad: Comonad[IO] = new Comonad[IO] {
+
+    override def extract[A](x: IO[A]): A = x.unsafeRunSync()
+
+    override def coflatMap[A, B](fa: IO[A])(f: IO[A] => B): IO[B] = IO.pure(f(fa))
+
+    override def map[A, B](fa: IO[A])(f: A => B): IO[B] = fa.map(f)
+  }
+
+  implicit val io2Task: IO ~> Task = new (IO ~> Task) {
+    override def apply[A](fa: IO[A]): Task[A] = fa.to[Task]
+  }
+}
+
+trait RPCAsyncImplicits extends FutureAsyncInstances with TaskAsyncInstances with IOAsyncInstances

--- a/rpc/src/main/scala/internal/service/service.scala
+++ b/rpc/src/main/scala/internal/service/service.scala
@@ -92,7 +92,7 @@ trait RPCService {
   val serviceBindings: Defn.Def = {
     val args: Seq[Term.Tuple] = requests.map(_.call)
     q"""
-       def bindService[F[_]](implicit algebra: $algName[F], HTask: _root_.freestyle.FSHandler[F, _root_.monix.eval.Task], ME: _root_.cats.MonadError[F, Throwable], C: _root_.cats.Comonad[F], S: _root_.monix.execution.Scheduler): _root_.io.grpc.ServerServiceDefinition =
+       def bindService[F[_]](implicit algebra: $algName[F], EFF: _root_.cats.effect.Effect[F], HTask: _root_.freestyle.FSHandler[F, _root_.monix.eval.Task], C: _root_.cats.Comonad[F], S: _root_.monix.execution.Scheduler): _root_.io.grpc.ServerServiceDefinition =
            new _root_.freestyle.rpc.internal.service.GRPCServiceDefBuilder(${Lit.String(
       algName.value)}, ..$args).apply
      """

--- a/rpc/src/main/scala/server/implicits.scala
+++ b/rpc/src/main/scala/server/implicits.scala
@@ -65,6 +65,7 @@ trait Helpers {
 
 object implicits
     extends CaptureInstances
+    with IOCapture
     with RPCAsyncImplicits
     with Syntax
     with Helpers

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.1-SNAPSHOT"
+version in ThisBuild := "0.4.1"


### PR DESCRIPTION
Until now, especially the unary endpoint was being executed based on the `apply` method, hence only `scala.concurrent.Future` was a valid Monad for the Server interpretation.

This PR fixes this issue requesting a `cats.effect.Effect` instance in order to be able to suspend all the side effects into the `F` context. Therefore, the servers that currently are interpreting to `scala.concurrent.Future` could move interpreting to `cats.effect.IO`, and then, they can still use the `unsafeToFuture` method in order to evaluate the effect and produce the result in a `scala.concurrent.Future`.

However, the new servers can now interpret to suspendable Monads, like the mentioned `cats.effect.IO` or `monix.eval.Task`.

There are two additional task implemented in this PR:

* Async Instances grouping (`cats.effect.IO`, `monix.eval.Task` and `scala.concurrent.Future`).
* It releases a new version `0.4.1`.