### PR TITLE
Reduces boilerplate when creating client instances

### DIFF
--- a/rpc/src/main/scala/internal/service/service.scala
+++ b/rpc/src/main/scala/internal/service/service.scala
@@ -125,10 +125,16 @@ trait RPCService {
     q"""
        $wartSuppress
        def client[M[_]: _root_.freestyle.async.AsyncContext](
-          channel: _root_.io.grpc.Channel,
-          options: _root_.io.grpc.CallOptions = _root_.io.grpc.CallOptions.DEFAULT)
-          (implicit H: _root_.freestyle.FSHandler[_root_.monix.eval.Task, M], E: _root_.scala.concurrent.ExecutionContext) : $clientName[M] =
-             new ${clientName.ctorRef(Ctor.Name(clientName.value))}[M](channel, options)
+         channelFor: _root_.freestyle.rpc.client.ManagedChannelFor,
+         channelConfigList: List[_root_.freestyle.rpc.client.ManagedChannelConfig] = List(
+           _root_.freestyle.rpc.client.UsePlaintext(true)),
+           options: _root_.io.grpc.CallOptions = _root_.io.grpc.CallOptions.DEFAULT)(
+         implicit H: _root_.freestyle.FSHandler[_root_.monix.eval.Task, M],
+             E: _root_.scala.concurrent.ExecutionContext): $clientName[M] = {
+         val managedChannelInterpreter =
+           new _root_.freestyle.rpc.client.ManagedChannelInterpreter[M](channelFor, channelConfigList)
+         new ${clientName.ctorRef(Ctor.Name(clientName.value))}[M](managedChannelInterpreter.build(channelFor, channelConfigList), options)
+       }
      """
 }
 

--- a/rpc/src/test/scala/TaglessUtils.scala
+++ b/rpc/src/test/scala/TaglessUtils.scala
@@ -254,24 +254,14 @@ object TaglessUtils {
     import freestyle.implicits._
     import freestyle.config.implicits._
 
-    def createManagedChannel: ManagedChannel = {
-
-      val channelFor: ManagedChannelFor =
-        ConfigForAddress[ChannelConfig.Op]("rpc.client.host", "rpc.client.port")
-          .interpret[Try] match {
-          case Success(c) => c
-          case Failure(e) =>
-            e.printStackTrace()
-            throw new RuntimeException("Unable to load the client configuration", e)
-        }
-
-      val channelConfigList: List[ManagedChannelConfig] = List(UsePlaintext(true))
-
-      val managedChannelInterpreter =
-        new ManagedChannelInterpreter[ConcurrentMonad](channelFor, channelConfigList)
-
-      managedChannelInterpreter.build(channelFor, channelConfigList)
-    }
+    def createManagedChannelFor: ManagedChannelFor =
+      ConfigForAddress[ChannelConfig.Op]("rpc.client.host", "rpc.client.port")
+        .interpret[Try] match {
+        case Success(c) => c
+        case Failure(e) =>
+          e.printStackTrace()
+          throw new RuntimeException("Unable to load the client configuration", e)
+      }
 
     def createServerConf(grpcConfigs: List[GrpcConfig]): ServerW =
       BuildServerFromConfig[ServerConfig.Op]("rpc.server.port", grpcConfigs)
@@ -340,7 +330,7 @@ object TaglessUtils {
     //////////////////////////////////
 
     implicit val taglessRPCServiceClient: TaglessRPCService.Client[ConcurrentMonad] =
-      TaglessRPCService.client[ConcurrentMonad](createManagedChannel)
+      TaglessRPCService.client[ConcurrentMonad](createManagedChannelFor)
 
     implicit val taglessRPCServiceClientHandler: TaglessRPCServiceClientHandler[ConcurrentMonad] =
       new TaglessRPCServiceClientHandler[ConcurrentMonad]

--- a/rpc/src/test/scala/Utils.scala
+++ b/rpc/src/test/scala/Utils.scala
@@ -253,24 +253,14 @@ object Utils {
     import freestyle.implicits._
     import freestyle.config.implicits._
 
-    def createManagedChannel: ManagedChannel = {
-
-      val channelFor: ManagedChannelFor =
-        ConfigForAddress[ChannelConfig.Op]("rpc.client.host", "rpc.client.port")
-          .interpret[Try] match {
-          case Success(c) => c
-          case Failure(e) =>
-            e.printStackTrace()
-            throw new RuntimeException("Unable to load the client configuration", e)
-        }
-
-      val channelConfigList: List[ManagedChannelConfig] = List(UsePlaintext(true))
-
-      val managedChannelInterpreter =
-        new ManagedChannelInterpreter[ConcurrentMonad](channelFor, channelConfigList)
-
-      managedChannelInterpreter.build(channelFor, channelConfigList)
-    }
+    def createManagedChannelFor: ManagedChannelFor =
+      ConfigForAddress[ChannelConfig.Op]("rpc.client.host", "rpc.client.port")
+        .interpret[Try] match {
+        case Success(c) => c
+        case Failure(e) =>
+          e.printStackTrace()
+          throw new RuntimeException("Unable to load the client configuration", e)
+      }
 
     def createServerConf(grpcConfigs: List[GrpcConfig]): ServerW =
       BuildServerFromConfig[ServerConfig.Op]("rpc.server.port", grpcConfigs)
@@ -339,7 +329,7 @@ object Utils {
     //////////////////////////////////
 
     implicit val freesRPCServiceClient: RPCService.Client[ConcurrentMonad] =
-      RPCService.client[ConcurrentMonad](createManagedChannel)
+      RPCService.client[ConcurrentMonad](createManagedChannelFor)
 
     implicit val freesRPCServiceClientHandler: FreesRPCServiceClientHandler[ConcurrentMonad] =
       new FreesRPCServiceClientHandler[ConcurrentMonad]


### PR DESCRIPTION
This PR reduces some boilerplate when creating RPC client instances:

Previously to this change, in order to create new client instances, users have to do something like the following:

```scala
import cats.effect.IO
import freestyle.rpc.client._
import io.grpc.ManagedChannel //notice a io.grpc.import

val channelFor: ManagedChannelFor = ManagedChannelForAddress("localhost", 8080)

val channelConfigList: List[ManagedChannelConfig] = List(UsePlaintext(true))

val managedChannelInterpreter =
  new ManagedChannelInterpreter[IO](channelFor, channelConfigList)

val channel: ManagedChannel = managedChannelInterpreter.build(channelFor, channelConfigList)

val client: YourService.Client[IO] = YourService.client[IO](channel)
```

After this change, `channelConfigList` would be optional since it has a default value: `_ = List(UsePlaintext(true))`. Additionally, clients won't receive a `io.grpc.ManagedChannel` as first argument anymore, instead it'll receive the `ManagedChannelFor` object. Hence, this would be the equivalent version of the code above:

```scala
val channelFor: ManagedChannelFor = ManagedChannelForAddress("localhost", 8080)
val client: YourService.Client[IO] = YourService.client[IO](channelFor)
```

Optionally, as we've mentioned, you could still pass a `List[ManagedChannelConfig]` as a second argument.
