### PR TITLE
Supports inner imports within @service macro.

### DIFF
--- a/rpc/src/test/scala/Utils.scala
+++ b/rpc/src/test/scala/Utils.scala
@@ -31,6 +31,8 @@ object Utils extends CommonUtils {
     @service
     trait RPCService[F[_]] {
 
+      import ExternalScope._
+
       @rpc(Protobuf) def notAllowed(b: Boolean): F[C]
 
       @rpc(Avro) def unary(a: A): F[C]
@@ -58,6 +60,9 @@ object Utils extends CommonUtils {
       @rpc(Avro)
       @stream[BidirectionalStreaming.type]
       def biStreaming(oe: Observable[E]): F[Observable[E]]
+
+      @rpc(Protobuf)
+      def scope(empty: Empty.type): F[External]
     }
 
   }
@@ -114,6 +119,10 @@ object Utils extends CommonUtils {
           }
 
         def save(e: E) = e // do something else with e?
+
+        import ExternalScope._
+
+        override def scope(empty: protocol.Empty.type): F[External] = C.capture(External(e1))
       }
 
     }

--- a/rpc/src/test/scala/models.scala
+++ b/rpc/src/test/scala/models.scala
@@ -25,3 +25,7 @@ case class C(foo: String, a: A)
 case class D(bar: Int)
 
 case class E(a: A, foo: String)
+
+object ExternalScope {
+  case class External(e: E)
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.1-SNAPSHOT"
+version in ThisBuild := "0.5.1"


### PR DESCRIPTION
This PR makes possible to have inner imports within the annotated @service trait:

```scala
@service
    trait RPCService[F[_]] {
      import ExternalScope._

      @rpc(Protobuf)
      def scope(empty: Empty.type): F[External]
    }
```

It also releases a new patch version -> **0.5.1**.