### PR TITLE
Excludes Guava from frees-async-guava

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,7 @@ lazy val rpc = project
         Seq(
           %%("frees-core", V.frees),
           %%("frees-async", V.frees),
-          %%("frees-async-guava", V.frees),
+          %%("frees-async-guava", V.frees) exclude ("com.google.guava", "guava"),
           %%("frees-async-cats-effect", V.frees),
           %%("frees-config", V.frees),
           %%("frees-logging", V.frees),

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.2-SNAPSHOT"
+version in ThisBuild := "0.5.2"


### PR DESCRIPTION
This PR makes that frees-rpc only relies on the gRPC guava version, that by these days, it's the `19.0`.