### PR TITLE
Mini cleanup after move to finally tagless

### DIFF
--- a/modules/config/src/main/scala/client/ChannelConfig.scala
+++ b/modules/config/src/main/scala/client/ChannelConfig.scala
@@ -19,6 +19,7 @@ package client
 package config
 
 import cats.Functor
+import cats.syntax.either._
 import cats.syntax.functor._
 import freestyle.tagless._
 import freestyle.tagless.config.ConfigM

--- a/modules/config/src/main/scala/client/ChannelConfig.scala
+++ b/modules/config/src/main/scala/client/ChannelConfig.scala
@@ -20,7 +20,6 @@ package config
 
 import cats.Functor
 import cats.syntax.functor._
-import cats.syntax.either._
 import freestyle.tagless._
 import freestyle.tagless.config.ConfigM
 

--- a/modules/config/src/main/scala/server/ServerConfig.scala
+++ b/modules/config/src/main/scala/server/ServerConfig.scala
@@ -19,6 +19,7 @@ package server
 package config
 
 import cats.Functor
+import cats.syntax.either._
 import cats.syntax.functor._
 import freestyle.tagless._
 import freestyle.tagless.config.ConfigM

--- a/modules/config/src/main/scala/server/ServerConfig.scala
+++ b/modules/config/src/main/scala/server/ServerConfig.scala
@@ -20,7 +20,6 @@ package config
 
 import cats.Functor
 import cats.syntax.functor._
-import cats.syntax.either._
 import freestyle.tagless._
 import freestyle.tagless.config.ConfigM
 

--- a/modules/internal/src/main/scala/server/calls.scala
+++ b/modules/internal/src/main/scala/server/calls.scala
@@ -19,6 +19,7 @@ package internal
 package server
 
 import cats.effect.{Effect, IO}
+import cats.syntax.functor._
 import io.grpc.stub.ServerCalls.{
   BidiStreamingMethod,
   ClientStreamingMethod,
@@ -64,7 +65,7 @@ object calls {
     override def invoke(request: Req, responseObserver: StreamObserver[Res]): Unit =
       EFF
         .runAsync(f(request)) {
-          case Right(obs) => IO(obs.subscribe(responseObserver))
+          case Right(obs) => IO(obs.subscribe(responseObserver)).void
           case Left(e)    => IO.raiseError(e) // this will throw, but consistent previous impl
         }
         .unsafeRunSync

--- a/modules/server/src/main/scala/implicits.scala
+++ b/modules/server/src/main/scala/implicits.scala
@@ -17,8 +17,8 @@
 package freestyle.rpc
 package server
 
-import cats.{Applicative, Monad}
-import cats.syntax.flatMap._
+import cats.{Applicative, Apply}
+import cats.syntax.apply._
 import cats.syntax.functor._
 import freestyle.rpc.async.RPCAsyncImplicits
 import freestyle.rpc.server.handlers.GrpcServerHandler
@@ -32,13 +32,8 @@ trait ServerImplicits {
 
 trait Helpers {
 
-  def server[F[_]: Monad](implicit S: GrpcServer[F]): F[Unit] = {
-    for {
-      _ <- S.start()
-      _ <- S.getPort
-      _ <- S.awaitTermination()
-    } yield ()
-  }
+  def server[F[_]: Apply](implicit S: GrpcServer[F]): F[Unit] =
+    S.start() *> S.getPort *> S.awaitTermination().void
 
 }
 

--- a/modules/server/src/main/scala/implicits.scala
+++ b/modules/server/src/main/scala/implicits.scala
@@ -33,7 +33,7 @@ trait ServerImplicits {
 trait Helpers {
 
   def server[F[_]: Apply](implicit S: GrpcServer[F]): F[Unit] =
-    S.start() *> S.getPort *> S.awaitTermination().void
+    S.start() *> S.awaitTermination().void
 
 }
 

--- a/modules/server/src/test/scala/CommonUtils.scala
+++ b/modules/server/src/test/scala/CommonUtils.scala
@@ -16,8 +16,7 @@
 
 package freestyle.rpc
 
-import cats.Apply
-import cats.syntax.apply._
+import cats.Functor
 import cats.syntax.functor._
 import freestyle.rpc.common._
 import freestyle.rpc.client._
@@ -47,11 +46,11 @@ trait CommonUtils {
 
   def createServerConf(grpcConfigs: List[GrpcConfig]): ServerW = ServerW(SC.port, grpcConfigs)
 
-  def serverStart[F[_]: Apply](implicit S: GrpcServer[F]): F[Unit] =
-    S.start() *> S.getPort.void
+  def serverStart[F[_]: Functor](implicit S: GrpcServer[F]): F[Unit] =
+    S.start().void
 
-  def serverStop[F[_]: Apply](implicit S: GrpcServer[F]): F[Unit] =
-    S.getPort *> S.shutdownNow().void
+  def serverStop[F[_]: Functor](implicit S: GrpcServer[F]): F[Unit] =
+    S.shutdownNow().void
 
   def debug(str: String): Unit =
     println(s"\n\n$str\n\n")

--- a/modules/server/src/test/scala/CommonUtils.scala
+++ b/modules/server/src/test/scala/CommonUtils.scala
@@ -16,8 +16,8 @@
 
 package freestyle.rpc
 
-import cats.Monad
-import cats.syntax.flatMap._
+import cats.Apply
+import cats.syntax.apply._
 import cats.syntax.functor._
 import freestyle.rpc.common._
 import freestyle.rpc.client._
@@ -47,19 +47,11 @@ trait CommonUtils {
 
   def createServerConf(grpcConfigs: List[GrpcConfig]): ServerW = ServerW(SC.port, grpcConfigs)
 
-  def serverStart[F[_]: Monad](implicit S: GrpcServer[F]): F[Unit] = {
-    for {
-      _ <- S.start()
-      _ <- S.getPort
-    } yield ()
-  }
+  def serverStart[F[_]: Apply](implicit S: GrpcServer[F]): F[Unit] =
+    S.start() *> S.getPort.void
 
-  def serverStop[F[_]: Monad](implicit S: GrpcServer[F]): F[Unit] = {
-    for {
-      _ <- S.getPort
-      _ <- S.shutdownNow()
-    } yield ()
-  }
+  def serverStop[F[_]: Apply](implicit S: GrpcServer[F]): F[Unit] =
+    S.getPort *> S.shutdownNow().void
 
   def debug(str: String): Unit =
     println(s"\n\n$str\n\n")

--- a/modules/server/src/test/scala/server/GrpcServerTests.scala
+++ b/modules/server/src/test/scala/server/GrpcServerTests.scala
@@ -19,7 +19,7 @@ package server
 
 import java.util.concurrent.TimeUnit
 
-import cats.Monad
+import cats.Apply
 import cats.syntax.apply._
 import freestyle.rpc.common.{ConcurrentMonad, SC}
 import io.grpc.{Server, ServerServiceDefinition}
@@ -46,7 +46,7 @@ class GrpcServerTests extends RpcServerTestSuite {
 
     "behaves as expected" in {
 
-      def program[F[_]: Monad](APP: GrpcServer[F]): F[Result] = {
+      def program[F[_]: Apply](APP: GrpcServer[F]): F[Result] = {
 
         import APP._
 


### PR DESCRIPTION
Were the `S.getPort` there from when frees-rpc did logging? Could those be removed now that is no longer the case?