### PR TITLE
Upgrades to Freestyle 0.6.1. Releases 0.9.0.

### DIFF
--- a/docs/src/main/tut/README.md
+++ b/docs/src/main/tut/README.md
@@ -510,7 +510,7 @@ import cats.effect.IO
 import freestyle.rpc.server._
 import freestyle.rpc.server.handlers._
 import freestyle.rpc.server.implicits._
-import freestyle.free.asyncCatsEffect.implicits._
+import freestyle.async.catsEffect.implicits._
 import service._
 
 object gserver {
@@ -593,7 +593,7 @@ So, taking into account all we have just said, how would our code look?
 import cats.implicits._
 import cats.effect.IO
 import freestyle.free.config.implicits._
-import freestyle.free.asyncCatsEffect.implicits._
+import freestyle.async.catsEffect.implicits._
 import freestyle.rpc.client._
 import freestyle.rpc.client.config._
 import freestyle.rpc.client.implicits._

--- a/modules/internal/src/main/scala/client/calls.scala
+++ b/modules/internal/src/main/scala/client/calls.scala
@@ -20,7 +20,7 @@ package client
 
 import cats.~>
 import freestyle.async.AsyncContext
-import freestyle.free.asyncGuava.implicits._
+import freestyle.async.guava.implicits._
 import io.grpc.{CallOptions, Channel, MethodDescriptor}
 import io.grpc.stub.{ClientCalls, StreamObserver}
 import monix.eval.Task
@@ -38,7 +38,7 @@ object calls {
       descriptor: MethodDescriptor[Req, Res],
       channel: Channel,
       options: CallOptions)(implicit AC: AsyncContext[M], E: ExecutionContext): M[Res] =
-    listenableFuture2Async.apply(
+    listenableFuture2Async(
       ClientCalls
         .futureUnaryCall(channel.newCall(descriptor, options), request))
 

--- a/modules/server/src/test/scala/withouttagless/Utils.scala
+++ b/modules/server/src/test/scala/withouttagless/Utils.scala
@@ -19,7 +19,7 @@ package withouttagless
 
 import cats.{~>, Applicative, Monad, MonadError}
 import freestyle.rpc.common._
-import freestyle.free.asyncCatsEffect.implicits._
+import freestyle.async.catsEffect.implicits._
 import freestyle.rpc.protocol._
 import freestyle.tagless.tagless
 import monix.eval.Task

--- a/modules/server/src/test/scala/withtagless/TaglessUtils.scala
+++ b/modules/server/src/test/scala/withtagless/TaglessUtils.scala
@@ -19,7 +19,7 @@ package withtagless
 
 import cats.{~>, Applicative, Monad, MonadError}
 import freestyle.tagless.tagless
-import freestyle.free.asyncCatsEffect.implicits._
+import freestyle.async.catsEffect.implicits._
 import freestyle.rpc.common._
 import freestyle.rpc.protocol._
 import monix.eval.Task

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -18,7 +18,7 @@ object ProjectPlugin extends AutoPlugin {
 
     lazy val V = new {
       val avro4s: String    = "1.8.0"
-      val frees: String     = "0.5.3"
+      val frees: String     = "0.6.1"
       val grpc: String      = "1.7.1"
       val pbdirect: String  = "0.0.8"
       val scalameta: String = "1.8.0"
@@ -44,8 +44,8 @@ object ProjectPlugin extends AutoPlugin {
         %%("cats-core"),
         %%("cats-effect"),
         %%("monix"),
-        %%("shapeless")  % Test,
-        %%("frees-core") % Test
+        %%("shapeless")           % Test,
+        %%("frees-core", V.frees) % Test
       )
     )
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.8.1-SNAPSHOT"
+version in ThisBuild := "0.9.0"


### PR DESCRIPTION
This PR upgrades to the latest version of Freestyle: `0.6.1`, as it includes some breaking changes since version 0.5.3, so it also releases a new minor version of `frees-rpc`: **0.9.0**.