### PR TITLE
gRPC Services Metrics using Prometheus

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,6 +56,29 @@ lazy val config = project
   .settings(moduleName := "frees-rpc-config")
   .settings(configSettings)
 
+lazy val interceptors = project
+  .in(file("modules/interceptors"))
+  .settings(moduleName := "frees-rpc-interceptors")
+  .settings(interceptorsSettings)
+
+lazy val `prometheus-shared` = project
+  .in(file("modules/prometheus/shared"))
+  .dependsOn(interceptors % "compile->compile;test->test")
+  .settings(moduleName := "frees-rpc-prometheus-shared")
+  .settings(prometheusSettings)
+
+lazy val `prometheus-server` = project
+  .in(file("modules/prometheus/server"))
+  .dependsOn(`prometheus-shared` % "compile->compile;test->test")
+  .dependsOn(server % "compile->compile;test->test")
+  .settings(moduleName := "frees-rpc-prometheus-server")
+
+lazy val `prometheus-client` = project
+  .in(file("modules/prometheus/client"))
+  .dependsOn(`prometheus-shared` % "compile->compile;test->test")
+  .dependsOn(client % "compile->compile;test->test")
+  .settings(moduleName := "frees-rpc-prometheus-client")
+
 //////////////////////////
 //// MODULES REGISTRY ////
 //////////////////////////
@@ -68,7 +91,11 @@ lazy val allModules: Seq[ProjectReference] = Seq(
   `client-netty`,
   `client-okhttp`,
   server,
-  config
+  config,
+  interceptors,
+  `prometheus-shared`,
+  `prometheus-client`,
+  `prometheus-server`
 )
 
 lazy val allModulesDeps: Seq[ClasspathDependency] =

--- a/modules/interceptors/src/main/scala/GrpcMethodInfo.scala
+++ b/modules/interceptors/src/main/scala/GrpcMethodInfo.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc
+package interceptors
+
+import io.grpc.MethodDescriptor
+import io.grpc.MethodDescriptor.MethodType
+
+/**
+ * This model encapsulates a friendly representation of an RPC [[io.grpc.MethodDescriptor]].
+ *
+ * @param serviceName Service name owning the method.
+ * @param fullMethodName Service full name, in format `full.serviceName/MethodName`.
+ * @param methodName Just the method name.
+ * @param `type` Method Type.
+ */
+case class GrpcMethodInfo(
+    serviceName: String,
+    fullMethodName: String,
+    methodName: String,
+    `type`: MethodType) {
+
+  def isClientStreaming: Boolean =
+    (`type` eq MethodType.CLIENT_STREAMING) || (`type` eq MethodType.BIDI_STREAMING)
+
+  def isServerStreaming: Boolean =
+    (`type` eq MethodType.SERVER_STREAMING) || (`type` eq MethodType.BIDI_STREAMING)
+}
+
+object GrpcMethodInfo {
+
+  def apply[Req, Res](methodDescriptor: MethodDescriptor[Req, Res]): GrpcMethodInfo = {
+
+    val serviceName = MethodDescriptor.extractFullServiceName(methodDescriptor.getFullMethodName)
+    // Full method names are of the form: "full.serviceName/MethodName". We extract the last part.
+    val methodName = methodDescriptor.getFullMethodName.substring(serviceName.length + 1)
+
+    GrpcMethodInfo(
+      serviceName,
+      methodDescriptor.getFullMethodName,
+      methodName,
+      methodDescriptor.getType)
+
+  }
+
+}

--- a/modules/interceptors/src/main/scala/implicits.scala
+++ b/modules/interceptors/src/main/scala/implicits.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc
+package interceptors
+
+import io.grpc.{ServerInterceptor, ServerInterceptors, ServerServiceDefinition}
+
+trait InterceptorSyntax {
+
+  implicit final def serviceDefinitionSyntax(s: ServerServiceDefinition): InterceptorOps =
+    new InterceptorOps(s)
+
+}
+
+final class InterceptorOps(val s: ServerServiceDefinition) extends AnyVal {
+
+  def interceptWith(i: ServerInterceptor): ServerServiceDefinition =
+    ServerInterceptors.intercept(s, i)
+
+}
+
+object implicits extends InterceptorSyntax

--- a/modules/prometheus/server/src/main/scala/MonitoringServerInterceptor.scala
+++ b/modules/prometheus/server/src/main/scala/MonitoringServerInterceptor.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc
+package prometheus
+package server
+
+import java.time.{Clock, Instant}
+
+import freestyle.rpc.interceptors.GrpcMethodInfo
+import freestyle.rpc.prometheus.shared.Configuration
+import io.grpc._
+
+case class MonitoringServerInterceptor(clock: Clock)(implicit CFG: Configuration)
+    extends ServerInterceptor {
+
+  val serverMetrics: ServerMetrics = ServerMetrics(CFG)
+
+  override def interceptCall[Req, Res](
+      call: ServerCall[Req, Res],
+      requestHeaders: Metadata,
+      next: ServerCallHandler[Req, Res]): ServerCall.Listener[Req] = {
+
+    val method: MethodDescriptor[Req, Res] = call.getMethodDescriptor
+    val metricsMethod: ServerMetricsForMethod =
+      ServerMetricsForMethod(GrpcMethodInfo(method), serverMetrics)
+
+    val monitoringCall: MonitoringServerCall[Req, Res] =
+      MonitoringServerCall[Req, Res](call, clock, metricsMethod)
+
+    MonitoringServerCallListener[Req](next.startCall(monitoringCall, requestHeaders), metricsMethod)
+  }
+}
+
+object MonitoringServerInterceptor {
+
+  def apply(implicit CFG: Configuration): MonitoringServerInterceptor =
+    MonitoringServerInterceptor(Clock.systemDefaultZone)(CFG)
+
+}
+
+case class MonitoringServerCall[Req, Res](
+    serverCall: ServerCall[Req, Res],
+    clock: Clock,
+    serverMetrics: ServerMetricsForMethod)(implicit CFG: Configuration)
+    extends ForwardingServerCall.SimpleForwardingServerCall[Req, Res](serverCall) {
+
+  private[this] val millisPerSecond = 1000L
+
+  private[this] val startInstant: Instant = clock.instant
+  reportStartMetrics()
+
+  override def close(status: Status, responseHeaders: Metadata): Unit = {
+    reportEndMetrics(status)
+    super.close(status, responseHeaders)
+  }
+
+  override def sendMessage(message: Res): Unit = {
+    if (serverMetrics.method.isServerStreaming) serverMetrics.recordStreamMessageSent()
+    super.sendMessage(message)
+  }
+
+  private[this] def reportStartMetrics(): Unit =
+    serverMetrics.recordCallStarted()
+
+  private[this] def reportEndMetrics(status: Status): Unit = {
+    serverMetrics.recordServerHandled(status.getCode)
+    if (CFG.isIncludeLatencyHistograms) {
+      val latencySec = (clock.millis - startInstant.toEpochMilli) / millisPerSecond.toDouble
+      serverMetrics.recordLatency(latencySec)
+    }
+  }
+}
+
+case class MonitoringServerCallListener[Req](
+    delegate: ServerCall.Listener[Req],
+    serverMetrics: ServerMetricsForMethod)
+    extends ForwardingServerCallListener[Req] {
+
+  override def onMessage(request: Req): Unit = {
+    if (serverMetrics.method.isClientStreaming) serverMetrics.recordStreamMessageReceived()
+    super.onMessage(request)
+  }
+}

--- a/modules/prometheus/server/src/main/scala/MonitoringServerInterceptor.scala
+++ b/modules/prometheus/server/src/main/scala/MonitoringServerInterceptor.scala
@@ -65,7 +65,7 @@ case class MonitoringServerCall[Req, Res](
 
   override def close(status: Status, responseHeaders: Metadata): Unit = {
     reportEndMetrics(status)
-    super.close(status, responseHeaders)
+    delegate().close(status, responseHeaders)
   }
 
   override def sendMessage(message: Res): Unit = {

--- a/modules/prometheus/server/src/main/scala/ServerMetrics.scala
+++ b/modules/prometheus/server/src/main/scala/ServerMetrics.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc
+package prometheus
+package server
+
+import freestyle.rpc.prometheus.shared.Configuration
+import io.prometheus.client._
+
+case class ServerMetrics(cfg: Configuration) {
+
+  import ServerMetrics._
+
+  val serverStarted: Counter = serverStartedBuilder.register(cfg.collectorRegistry)
+  val serverHandled: Counter = serverHandledBuilder.register(cfg.collectorRegistry)
+  val serverStreamMessagesReceived: Counter =
+    serverStreamMessagesReceivedBuilder.register(cfg.collectorRegistry)
+  val serverStreamMessagesSent: Counter =
+    serverStreamMessagesSentBuilder.register(cfg.collectorRegistry)
+  val serverHandledLatencySeconds: Option[Histogram] =
+    if (cfg.isIncludeLatencyHistograms)
+      Some(
+        serverHandledLatencySecondsBuilder
+          .buckets(cfg.latencyBuckets: _*)
+          .register(cfg.collectorRegistry))
+    else None
+}
+
+object ServerMetrics {
+
+  val serverStartedBuilder: Counter.Builder = Counter.build
+    .namespace("grpc")
+    .subsystem("server")
+    .name("started_total")
+    .labelNames("grpc_type", "grpc_service", "grpc_method")
+    .help("Total number of RPCs started on the server.")
+
+  val serverHandledBuilder: Counter.Builder = Counter.build
+    .namespace("grpc")
+    .subsystem("server")
+    .name("handled_total")
+    .labelNames("grpc_type", "grpc_service", "grpc_method", "grpc_code")
+    .help("Total number of RPCs completed on the server, regardless of success or failure.")
+
+  val serverHandledLatencySecondsBuilder: Histogram.Builder = Histogram.build
+    .namespace("grpc")
+    .subsystem("server")
+    .name("handled_latency_seconds")
+    .labelNames("grpc_type", "grpc_service", "grpc_method")
+    .help("Histogram of response latency (seconds) of gRPC that had been application-level handled by the server.")
+
+  val serverStreamMessagesReceivedBuilder: Counter.Builder = Counter.build
+    .namespace("grpc")
+    .subsystem("server")
+    .name("msg_received_total")
+    .labelNames("grpc_type", "grpc_service", "grpc_method")
+    .help("Total number of stream messages received from the client.")
+
+  val serverStreamMessagesSentBuilder: Counter.Builder = Counter.build
+    .namespace("grpc")
+    .subsystem("server")
+    .name("msg_sent_total")
+    .labelNames("grpc_type", "grpc_service", "grpc_method")
+    .help("Total number of stream messages sent by the server.")
+}

--- a/modules/prometheus/server/src/main/scala/ServerMetricsForMethod.scala
+++ b/modules/prometheus/server/src/main/scala/ServerMetricsForMethod.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc
+package prometheus
+package server
+
+import freestyle.rpc.interceptors.GrpcMethodInfo
+import io.grpc.Status.Code
+import io.prometheus.client.SimpleCollector
+
+case class ServerMetricsForMethod(method: GrpcMethodInfo, serverMetrics: ServerMetrics) {
+
+  import serverMetrics._
+
+  def recordCallStarted(): Unit =
+    addLabels(serverStarted).inc()
+
+  def recordServerHandled(code: Code): Unit =
+    addLabels(serverHandled, code.toString).inc()
+
+  def recordStreamMessageReceived(): Unit =
+    addLabels(serverStreamMessagesReceived).inc()
+
+  def recordStreamMessageSent(): Unit =
+    addLabels(serverStreamMessagesSent).inc()
+
+  def recordLatency(latencySec: Double): Unit =
+    serverHandledLatencySeconds foreach (_ =>
+      addLabels(serverHandledLatencySeconds.get).observe(latencySec))
+
+  private def addLabels[T](collector: SimpleCollector[T], labels: String*): T =
+    collector.labels(
+      List(method.`type`.toString, method.serviceName, method.methodName) ++ labels.toList: _*)
+
+}

--- a/modules/prometheus/server/src/test/scala/InterceptorsRuntime.scala
+++ b/modules/prometheus/server/src/test/scala/InterceptorsRuntime.scala
@@ -21,7 +21,6 @@ package server
 import freestyle.rpc.common.ConcurrentMonad
 import freestyle.rpc.prometheus.shared.Configuration
 import freestyle.rpc.withouttagless.Utils._
-import io.grpc.ServerInterceptors
 import io.prometheus.client.CollectorRegistry
 
 case class InterceptorsRuntime(
@@ -35,6 +34,7 @@ case class InterceptorsRuntime(
   import freestyle.rpc.server._
   import freestyle.rpc.server.implicits._
   import freestyle.async.catsEffect.implicits._
+  import freestyle.rpc.interceptors.implicits._
 
   //////////////////////////////////
   // Server Runtime Configuration //
@@ -43,8 +43,7 @@ case class InterceptorsRuntime(
   lazy val monitorInterceptor = MonitoringServerInterceptor(configuration.withCollectorRegistry(cr))
 
   lazy val grpcConfigs: List[GrpcConfig] = List(
-    AddService(
-      ServerInterceptors.intercept(RPCService.bindService[ConcurrentMonad], monitorInterceptor))
+    AddService(RPCService.bindService[ConcurrentMonad].interceptWith(monitorInterceptor))
   )
 
   implicit lazy val serverW: ServerW = createServerConfOnRandomPort(grpcConfigs)

--- a/modules/prometheus/server/src/test/scala/InterceptorsRuntime.scala
+++ b/modules/prometheus/server/src/test/scala/InterceptorsRuntime.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc
+package prometheus
+package server
+
+import freestyle.rpc.common.ConcurrentMonad
+import freestyle.rpc.prometheus.shared.Configuration
+import freestyle.rpc.withouttagless.Utils._
+import io.grpc.ServerInterceptors
+import io.prometheus.client.CollectorRegistry
+
+case class InterceptorsRuntime(
+    configuration: Configuration = Configuration.defaultBasicMetrics,
+    cr: CollectorRegistry = new CollectorRegistry())
+    extends CommonUtils {
+
+  import service._
+  import handlers.server._
+  import handlers.client._
+  import freestyle.rpc.server._
+  import freestyle.rpc.server.implicits._
+  import freestyle.async.catsEffect.implicits._
+
+  //////////////////////////////////
+  // Server Runtime Configuration //
+  //////////////////////////////////
+
+  lazy val monitorInterceptor = MonitoringServerInterceptor(configuration.withCollectorRegistry(cr))
+
+  lazy val grpcConfigs: List[GrpcConfig] = List(
+    AddService(
+      ServerInterceptors.intercept(RPCService.bindService[ConcurrentMonad], monitorInterceptor))
+  )
+
+  implicit lazy val serverW: ServerW = createServerConfOnRandomPort(grpcConfigs)
+
+  implicit lazy val freesRPCHandler: ServerRPCService[ConcurrentMonad] =
+    new ServerRPCService[ConcurrentMonad]
+
+  //////////////////////////////////
+  // Client Runtime Configuration //
+  //////////////////////////////////
+
+  implicit lazy val freesRPCServiceClient: RPCService.Client[ConcurrentMonad] =
+    RPCService.client[ConcurrentMonad](createManagedChannelForPort(serverW.port))
+
+  implicit lazy val freesRPCServiceClientHandler: FreesRPCServiceClientHandler[ConcurrentMonad] =
+    new FreesRPCServiceClientHandler[ConcurrentMonad]
+
+}

--- a/modules/prometheus/server/src/test/scala/MonitorServerInterceptorTests.scala
+++ b/modules/prometheus/server/src/test/scala/MonitorServerInterceptorTests.scala
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc
+package prometheus
+package server
+
+import freestyle.rpc.common._
+import freestyle.rpc.prometheus.shared.Configuration
+import freestyle.rpc.withouttagless.Utils.client.MyRPCClient
+import io.prometheus.client.{Collector, CollectorRegistry}
+
+import scala.collection.JavaConverters._
+
+class MonitorServerInterceptorTests extends RpcBaseTestSuite {
+
+  import freestyle.rpc.server.implicits._
+  import freestyle.rpc.withouttagless.Utils.database._
+  import RegistryHelper._
+
+  "MonitorServerInterceptor for Prometheus" should {
+
+    "work for unary RPC metrics" in {
+
+      def clientProgram[F[_]](implicit APP: MyRPCClient[F]): F[C] =
+        APP.u(a1.x, a1.y)
+
+      val serverRuntime: InterceptorsRuntime = InterceptorsRuntime()
+
+      import serverRuntime._
+      serverRuntime.serverStart[ConcurrentMonad].unsafeRunSync()
+      implicit val CR: CollectorRegistry = serverRuntime.cr
+
+      clientProgram[ConcurrentMonad].unsafeRunSync()
+
+      findRecordedMetricOrThrow("grpc_server_started_total").samples.size() shouldBe 1
+      findRecordedMetricOrThrow("grpc_server_msg_received_total").samples shouldBe empty
+      findRecordedMetricOrThrow("grpc_server_msg_sent_total").samples shouldBe empty
+
+      val handledSamples =
+        findRecordedMetricOrThrow("grpc_server_handled_total").samples.asScala.toList
+      handledSamples.size shouldBe 1
+      handledSamples.headOption.foreach { s =>
+        s.labelValues.asScala.toList should contain theSameElementsAs Vector(
+          "UNARY",
+          "RPCService",
+          "unary",
+          "OK")
+      }
+      handledSamples.headOption.map { s =>
+        s.value shouldBe 0.5 +- 0.5
+      }
+
+      serverRuntime.serverStop[ConcurrentMonad].unsafeRunSync()
+    }
+
+    "work for client streaming RPC metrics" in {
+
+      def clientProgram[F[_]](implicit APP: MyRPCClient[F]): F[D] =
+        APP.cs(cList, i)
+
+      val serverRuntime: InterceptorsRuntime = InterceptorsRuntime()
+
+      import serverRuntime._
+      serverRuntime.serverStart[ConcurrentMonad].unsafeRunSync()
+      implicit val CR: CollectorRegistry = serverRuntime.cr
+
+      clientProgram[ConcurrentMonad].unsafeRunSync()
+
+      findRecordedMetricOrThrow("grpc_server_started_total").samples.size() shouldBe 1
+      findRecordedMetricOrThrow("grpc_server_msg_received_total").samples.size() shouldBe 1
+      findRecordedMetricOrThrow("grpc_server_msg_sent_total").samples shouldBe empty
+
+      val handledSamples =
+        findRecordedMetricOrThrow("grpc_server_handled_total").samples.asScala.toList
+      handledSamples.size shouldBe 1
+      handledSamples.headOption.foreach { s =>
+        s.value shouldBe 0.5 +- 0.5
+        s.labelValues.asScala.toList should contain theSameElementsAs Vector(
+          "CLIENT_STREAMING",
+          "RPCService",
+          "clientStreaming",
+          "OK")
+      }
+
+      serverRuntime.serverStop[ConcurrentMonad].unsafeRunSync()
+    }
+
+    "work for server streaming RPC metrics" in {
+
+      def clientProgram[F[_]](implicit APP: MyRPCClient[F]): F[List[C]] =
+        APP.ss(a2.x, a2.y)
+
+      val serverRuntime: InterceptorsRuntime = InterceptorsRuntime()
+
+      import serverRuntime._
+      serverRuntime.serverStart[ConcurrentMonad].unsafeRunSync()
+      implicit val CR: CollectorRegistry = serverRuntime.cr
+
+      val response: List[C] = clientProgram[ConcurrentMonad].unsafeRunSync()
+
+      findRecordedMetricOrThrow("grpc_server_started_total").samples.size() shouldBe 1
+      findRecordedMetricOrThrow("grpc_server_msg_received_total").samples shouldBe empty
+      findRecordedMetricOrThrow("grpc_server_msg_sent_total").samples.size() shouldBe 1
+
+      val handledSamples =
+        findRecordedMetricOrThrow("grpc_server_handled_total").samples.asScala.toList
+      handledSamples.size shouldBe 1
+      handledSamples.headOption.foreach { s =>
+        s.value shouldBe 0.5 +- 0.5
+        s.labelValues.asScala.toList should contain theSameElementsAs Vector(
+          "SERVER_STREAMING",
+          "RPCService",
+          "serverStreaming",
+          "OK"
+        )
+      }
+
+      val messagesSent =
+        findRecordedMetricOrThrow("grpc_server_msg_sent_total").samples.asScala.toList
+
+      messagesSent.headOption.foreach { s =>
+        s.value should be >= 0.doubleValue()
+        s.value should be <= response.size.doubleValue()
+        s.labelValues.asScala.toList should contain theSameElementsAs Vector(
+          "SERVER_STREAMING",
+          "RPCService",
+          "serverStreaming"
+        )
+      }
+
+      serverRuntime.serverStop[ConcurrentMonad].unsafeRunSync()
+    }
+
+    "work for bidirectional streaming RPC metrics" in {
+
+      def clientProgram[F[_]](implicit APP: MyRPCClient[F]): F[E] =
+        APP.bs(eList)
+
+      val serverRuntime: InterceptorsRuntime = InterceptorsRuntime()
+
+      import serverRuntime._
+      serverRuntime.serverStart[ConcurrentMonad].unsafeRunSync()
+      implicit val CR: CollectorRegistry = serverRuntime.cr
+
+      clientProgram[ConcurrentMonad].unsafeRunSync()
+
+      findRecordedMetricOrThrow("grpc_server_started_total").samples.size() shouldBe 1
+      findRecordedMetricOrThrow("grpc_server_msg_received_total").samples.size() shouldBe 1
+      findRecordedMetricOrThrow("grpc_server_msg_sent_total").samples.size() shouldBe 1
+
+      val handledSamples =
+        findRecordedMetricOrThrow("grpc_server_handled_total").samples.asScala.toList
+      handledSamples.size shouldBe 1
+      handledSamples.headOption.foreach { s =>
+        s.value shouldBe 0.5 +- 0.5
+        s.labelValues.asScala.toList should contain theSameElementsAs Vector(
+          "BIDI_STREAMING",
+          "RPCService",
+          "biStreaming",
+          "OK")
+      }
+
+      serverRuntime.serverStop[ConcurrentMonad].unsafeRunSync()
+    }
+
+    "work when no histogram is enabled" in {
+
+      def clientProgram[F[_]](implicit APP: MyRPCClient[F]): F[C] =
+        APP.u(a1.x, a1.y)
+
+      val serverRuntime: InterceptorsRuntime = InterceptorsRuntime()
+
+      import serverRuntime._
+      serverRuntime.serverStart[ConcurrentMonad].unsafeRunSync()
+      implicit val CR: CollectorRegistry = serverRuntime.cr
+
+      clientProgram[ConcurrentMonad].unsafeRunSync()
+
+      findRecordedMetric("grpc_server_handled_latency_seconds") shouldBe None
+
+      serverRuntime.serverStop[ConcurrentMonad].unsafeRunSync()
+    }
+
+    "work when histogram is enabled" in {
+
+      def clientProgram[F[_]](implicit APP: MyRPCClient[F]): F[C] =
+        APP.u(a1.x, a1.y)
+
+      val serverRuntime: InterceptorsRuntime = InterceptorsRuntime(Configuration.defaultAllMetrics)
+
+      import serverRuntime._
+      serverRuntime.serverStart[ConcurrentMonad].unsafeRunSync()
+      implicit val CR: CollectorRegistry = serverRuntime.cr
+
+      clientProgram[ConcurrentMonad].unsafeRunSync()
+
+      val metric: Option[Collector.MetricFamilySamples] =
+        findRecordedMetric("grpc_server_handled_latency_seconds")
+
+      metric shouldBe defined
+      metric.map { m =>
+        m.samples.size should be > 0
+      }
+
+      serverRuntime.serverStop[ConcurrentMonad].unsafeRunSync()
+    }
+
+    "work for different buckets" in {
+
+      def clientProgram[F[_]](implicit APP: MyRPCClient[F]): F[C] =
+        APP.u(a1.x, a1.y)
+
+      val buckets: Vector[Double] = Vector[Double](0.1, 0.2, 0.8)
+      val serverRuntime: InterceptorsRuntime =
+        InterceptorsRuntime(Configuration.defaultAllMetrics.withLatencyBuckets(buckets))
+
+      import serverRuntime._
+      serverRuntime.serverStart[ConcurrentMonad].unsafeRunSync()
+      implicit val CR: CollectorRegistry = serverRuntime.cr
+
+      clientProgram[ConcurrentMonad].unsafeRunSync()
+
+      countSamples(
+        "grpc_server_handled_latency_seconds",
+        "grpc_server_handled_latency_seconds_bucket") shouldBe (buckets.size + 1)
+
+      serverRuntime.serverStop[ConcurrentMonad].unsafeRunSync()
+    }
+
+    "work when combining multiple calls" in {
+
+      def unary[F[_]](implicit APP: MyRPCClient[F]): F[C] =
+        APP.u(a1.x, a1.y)
+
+      def clientStreaming[F[_]](implicit APP: MyRPCClient[F]): F[D] =
+        APP.cs(cList, i)
+
+      val serverRuntime: InterceptorsRuntime = InterceptorsRuntime()
+
+      import serverRuntime._
+      serverRuntime.serverStart[ConcurrentMonad].unsafeRunSync()
+      implicit val CR: CollectorRegistry = serverRuntime.cr
+
+      (for {
+        a <- unary[ConcurrentMonad]
+        b <- clientStreaming[ConcurrentMonad]
+      } yield (a, b)).unsafeRunSync()
+
+      findRecordedMetricOrThrow("grpc_server_started_total").samples.size() shouldBe 2
+      findRecordedMetricOrThrow("grpc_server_handled_total").samples.size() shouldBe 2
+
+      serverRuntime.serverStop[ConcurrentMonad].unsafeRunSync()
+    }
+
+  }
+}

--- a/modules/prometheus/server/src/test/scala/RegistryHelper.scala
+++ b/modules/prometheus/server/src/test/scala/RegistryHelper.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc
+package prometheus
+package server
+
+import io.prometheus.client._
+import scala.collection.JavaConverters._
+
+object RegistryHelper {
+
+  def findRecordedMetric(name: String)(
+      implicit CR: CollectorRegistry): Option[Collector.MetricFamilySamples] =
+    CR.metricFamilySamples.asScala.find(_.name == name)
+
+  def findRecordedMetricOrThrow(name: String)(
+      implicit CR: CollectorRegistry): Collector.MetricFamilySamples =
+    findRecordedMetric(name).getOrElse(
+      throw new IllegalArgumentException(s"Could not find metric with name: $name"))
+
+  def extractMetricValue(name: String)(implicit CR: CollectorRegistry): Double = {
+    val result = findRecordedMetricOrThrow(name)
+    result.samples.asScala.headOption
+      .map(_.value)
+      .getOrElse(throw new IllegalArgumentException(
+        s"Expected one value, but got ${result.samples.size} for metric $name"))
+  }
+
+  def countSamples(metricName: String, sampleName: String)(implicit CR: CollectorRegistry): Int =
+    CR.metricFamilySamples.asScala
+      .filter(_.name == metricName)
+      .map { sample =>
+        sample.samples.asScala.count(_.name == sampleName)
+      }
+      .sum
+
+  def printRegistry(collectorRegistry: CollectorRegistry): Unit =
+    collectorRegistry.metricFamilySamples.asScala.foreach(println)
+
+}

--- a/modules/prometheus/shared/src/main/scala/Configuration.scala
+++ b/modules/prometheus/shared/src/main/scala/Configuration.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc
+package prometheus
+package shared
+
+import io.prometheus.client.CollectorRegistry
+
+case class Configuration(
+    isIncludeLatencyHistograms: Boolean,
+    collectorRegistry: CollectorRegistry,
+    latencyBuckets: Vector[Double]) {
+
+  def withCollectorRegistry(c: CollectorRegistry): Configuration =
+    this.copy(collectorRegistry = c)
+
+  def withLatencyBuckets(lb: Vector[Double]): Configuration =
+    this.copy(latencyBuckets = lb)
+
+}
+
+object Configuration {
+
+  private[this] val defaultLatencyBuckets: Vector[Double] =
+    Vector[Double](.001, .005, .01, .05, 0.075, .1, .25, .5, 1, 2, 5, 10)
+
+  def defaultBasicMetrics: Configuration =
+    Configuration(
+      isIncludeLatencyHistograms = false,
+      CollectorRegistry.defaultRegistry,
+      defaultLatencyBuckets)
+
+  def defaultAllMetrics: Configuration =
+    Configuration(
+      isIncludeLatencyHistograms = true,
+      CollectorRegistry.defaultRegistry,
+      defaultLatencyBuckets)
+
+}

--- a/modules/server/src/test/scala/withouttagless/Utils.scala
+++ b/modules/server/src/test/scala/withouttagless/Utils.scala
@@ -199,11 +199,19 @@ object Utils extends CommonUtils {
         override def cs(cList: List[C], bar: Int): F[D] =
           client.clientStreaming(Observable.fromIterable(cList.map(c => c.a)))
 
+        import cats.syntax.functor._
         override def bs(eList: List[E]): F[E] =
           T2F(
             client
               .biStreaming(Observable.fromIterable(eList))
-              .firstL)
+              .zipWithIndex
+              .map {
+                case (c, i) =>
+                  debug(s"[CLIENT] Result #$i: $c")
+                  c
+              }
+              .toListL
+          ).map(_.head)
 
       }
 
@@ -211,7 +219,7 @@ object Utils extends CommonUtils {
 
   }
 
-  trait FreesRuntime extends CommonRuntime {
+  trait FreesRuntime {
 
     import service._
     import handlers.server._

--- a/modules/server/src/test/scala/withtagless/TaglessUtils.scala
+++ b/modules/server/src/test/scala/withtagless/TaglessUtils.scala
@@ -203,7 +203,7 @@ object TaglessUtils extends CommonUtils {
 
   }
 
-  trait TaglessRuntime extends CommonRuntime {
+  trait TaglessRuntime {
 
     import service._
     import handlers.server._

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -100,6 +100,18 @@ object ProjectPlugin extends AutoPlugin {
       )
     )
 
+    lazy val interceptorsSettings: Seq[Def.Setting[_]] = Seq(
+      libraryDependencies ++= Seq(
+        %("grpc-core", V.grpc)
+      )
+    )
+
+    lazy val prometheusSettings = Seq(
+      libraryDependencies ++= Seq(
+        "io.prometheus" % "simpleclient" % "0.1.0"
+      )
+    )
+
     lazy val docsSettings = Seq(
       // Pointing to https://github.com/frees-io/freestyle/tree/master/docs/src/main/tut/docs/rpc
       tutTargetDirectory := baseDirectory.value.getParentFile.getParentFile / "docs" / "src" / "main" / "tut" / "docs" / "rpc"


### PR DESCRIPTION
This PR adds some new optional artifacts that you might want to add to your build in order to monitor your `gRPC` services.

Concretely, adding:

```
libraryDependencies += "io.frees" %% "frees-rpc-prometheus-server" % "x.y.z"
```

Your RPC services will be able to intercept every RPC call on the server side and collect metrics that you could render in your dashboard, using [Prometheus](https://prometheus.io/).

Adding services without intercepting calls:

```scala
lazy val grpcConfigs: List[GrpcConfig] = List(
  AddService(RPCService.bindService[ConcurrentMonad])
)
```

Intercepting calls with [Prometheus](https://prometheus.io/):

```scala
import freestyle.rpc.interceptors.implicits._

lazy val cr: CollectorRegistry = new CollectorRegistry()
lazy val monitorInterceptor = MonitoringServerInterceptor(configuration.withCollectorRegistry(cr))

lazy val grpcConfigs: List[GrpcConfig] = List(
  AddService(RPCService.bindService[ConcurrentMonad].interceptWith(monitorInterceptor))
)
```

Next steps:

* Support Client Metrics with Prometheus
* Support http://metrics.dropwizard.io/4.0.0/

Inspired by:
* https://github.com/grpc-ecosystem/java-grpc-prometheus
* https://github.com/grpc-ecosystem/go-grpc-prometheus.

