### PR TITLE
Metrics DSL

### DIFF
--- a/modules/interceptors/src/main/scala/metrics.scala
+++ b/modules/interceptors/src/main/scala/metrics.scala
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc
+package interceptors
+
+sealed abstract class MetricsFor(val value: String) extends Product with Serializable
+case object ServerMetrics                           extends MetricsFor(value = "server")
+case object ClientMetrics                           extends MetricsFor(value = "client")
+
+final case class MetricType(
+    namespace: String,
+    subsystem: MetricsFor,
+    name: String,
+    labelNames: List[String],
+    description: String) {
+
+  def toMetricString = s"${namespace}_${subsystem.value}_$name"
+
+}
+
+object MetricType {
+
+  def apply(
+      subsystem: MetricsFor,
+      name: String,
+      labelNames: List[String],
+      description: String): MetricType =
+    MetricType(metrics.namespace, subsystem, name, labelNames, description)
+
+}
+
+object metrics {
+
+  // Namespaces:
+
+  val namespace: String = "grpc"
+
+  // Metrics names:
+
+  private[this] val startedTotal: String            = "started_total"
+  private[this] val handledTotal: String            = "handled_total"
+  private[this] val handledLatencySeconds: String   = "handled_latency_seconds"
+  private[this] val completed: String               = "completed"
+  private[this] val completedLatencySeconds: String = "completed_latency_seconds"
+  private[this] val msgReceivedTotal: String        = "msg_received_total"
+  private[this] val msgSentTotal: String            = "msg_sent_total"
+
+  // Labels:
+
+  private[this] val grpcType: String    = "grpc_type"
+  private[this] val grpcService: String = "grpc_service"
+  private[this] val grpcMethod: String  = "grpc_method"
+  private[this] val grpcCode: String    = "grpc_code"
+
+  // Misc:
+
+  private[this] val baseLabels: List[String] = List(grpcType, grpcService, grpcMethod)
+
+  // Client - Predefined metrics:
+
+  val clientMetricRpcStarted: MetricType =
+    MetricType(
+      ClientMetrics,
+      startedTotal,
+      baseLabels,
+      "Total number of RPCs started on the client.")
+  val clientMetricRpcCompleted: MetricType =
+    MetricType(
+      ClientMetrics,
+      completed,
+      baseLabels :+ grpcCode,
+      "Total number of RPCs completed on the client, regardless of success or failure.")
+  val clientMetricCompletedLatencySeconds: MetricType =
+    MetricType(
+      ClientMetrics,
+      completedLatencySeconds,
+      baseLabels,
+      "Histogram of rpc response latency (in seconds) for completed rpcs.")
+  val clientMetricStreamMessagesReceived: MetricType =
+    MetricType(
+      ClientMetrics,
+      msgReceivedTotal,
+      baseLabels,
+      "Total number of stream messages received from the server.")
+  val clientMetricStreamMessagesSent: MetricType =
+    MetricType(
+      ClientMetrics,
+      msgSentTotal,
+      baseLabels,
+      "Total number of stream messages sent by the client.")
+
+  // Server - Predefined metrics:
+
+  val serverMetricRpcStarted: MetricType =
+    MetricType(
+      ServerMetrics,
+      startedTotal,
+      baseLabels,
+      "Total number of RPCs started on the server.")
+  val serverMetricHandledCompleted: MetricType =
+    MetricType(
+      ServerMetrics,
+      handledTotal,
+      baseLabels :+ grpcCode,
+      "Total number of RPCs completed on the server, regardless of success or failure.")
+  val serverMetricHandledLatencySeconds: MetricType =
+    MetricType(
+      ServerMetrics,
+      handledLatencySeconds,
+      baseLabels,
+      "Histogram of response latency (seconds) of gRPC that had been application-level handled by the server."
+    )
+  val serverMetricStreamMessagesReceived: MetricType =
+    MetricType(
+      ServerMetrics,
+      msgReceivedTotal,
+      baseLabels,
+      "Total number of stream messages received from the client.")
+  val serverMetricStreamMessagesSent: MetricType =
+    MetricType(
+      ServerMetrics,
+      msgSentTotal,
+      baseLabels,
+      "Total number of stream messages sent by the server.")
+}

--- a/modules/prometheus/client/src/main/scala/ClientMetrics.scala
+++ b/modules/prometheus/client/src/main/scala/ClientMetrics.scala
@@ -23,7 +23,23 @@ import io.prometheus.client._
 
 case class ClientMetrics(cfg: Configuration) {
 
-  import ClientMetrics._
+  import freestyle.rpc.interceptors.metrics._
+  import freestyle.rpc.prometheus.implicits._
+
+  private[this] val rpcStartedBuilder: Counter.Builder =
+    clientMetricRpcStarted.toCounterBuilder
+
+  private[this] val rpcCompletedBuilder: Counter.Builder =
+    clientMetricRpcCompleted.toCounterBuilder
+
+  private[this] val completedLatencySecondsBuilder: Histogram.Builder =
+    clientMetricCompletedLatencySeconds.toHistogramBuilder
+
+  private[this] val streamMessagesReceivedBuilder: Counter.Builder =
+    clientMetricStreamMessagesReceived.toCounterBuilder
+
+  private[this] val streamMessagesSentBuilder: Counter.Builder =
+    clientMetricStreamMessagesSent.toCounterBuilder
 
   val rpcStarted: Counter   = rpcStartedBuilder.register(cfg.collectorRegistry)
   val rpcCompleted: Counter = rpcCompletedBuilder.register(cfg.collectorRegistry)
@@ -38,42 +54,4 @@ case class ClientMetrics(cfg: Configuration) {
           .buckets(cfg.latencyBuckets: _*)
           .register(cfg.collectorRegistry))
     else None
-}
-
-object ClientMetrics {
-
-  val rpcStartedBuilder: Counter.Builder = Counter.build
-    .namespace("grpc")
-    .subsystem("client")
-    .name("started_total")
-    .labelNames("grpc_type", "grpc_service", "grpc_method")
-    .help("Total number of RPCs started on the client.")
-
-  val rpcCompletedBuilder: Counter.Builder = Counter.build
-    .namespace("grpc")
-    .subsystem("client")
-    .name("completed")
-    .labelNames("grpc_type", "grpc_service", "grpc_method", "grpc_code")
-    .help("Total number of RPCs completed on the client, regardless of success or failure.")
-
-  val completedLatencySecondsBuilder: Histogram.Builder = Histogram.build
-    .namespace("grpc")
-    .subsystem("client")
-    .name("completed_latency_seconds")
-    .labelNames("grpc_type", "grpc_service", "grpc_method")
-    .help("Histogram of rpc response latency (in seconds) for completed rpcs.")
-
-  val streamMessagesReceivedBuilder: Counter.Builder = Counter.build
-    .namespace("grpc")
-    .subsystem("client")
-    .name("msg_received_total")
-    .labelNames("grpc_type", "grpc_service", "grpc_method")
-    .help("Total number of stream messages received from the server.")
-
-  val streamMessagesSentBuilder: Counter.Builder = Counter.build
-    .namespace("grpc")
-    .subsystem("client")
-    .name("msg_sent_total")
-    .labelNames("grpc_type", "grpc_service", "grpc_method")
-    .help("Total number of stream messages sent by the client.")
 }

--- a/modules/prometheus/shared/src/main/scala/implicits.scala
+++ b/modules/prometheus/shared/src/main/scala/implicits.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc
+package prometheus
+
+import freestyle.rpc.interceptors.MetricType
+import io.prometheus.client.{Counter, Histogram}
+
+trait MetricsTypeSyntax {
+
+  implicit final def metricsTypeSyntax(metricType: MetricType): MetricTypeOps =
+    new MetricTypeOps(metricType)
+
+}
+
+final class MetricTypeOps(val metricType: MetricType) extends AnyVal {
+
+  import metricType._
+
+  def toCounterBuilder: Counter.Builder =
+    Counter.build
+      .namespace(namespace)
+      .subsystem(subsystem.value)
+      .name(name)
+      .labelNames(labelNames: _*)
+      .help(description)
+
+  def toHistogramBuilder: Histogram.Builder =
+    Histogram.build
+      .namespace(namespace)
+      .subsystem(subsystem.value)
+      .name(name)
+      .labelNames(labelNames: _*)
+      .help(description)
+
+}
+
+object implicits extends MetricsTypeSyntax


### PR DESCRIPTION
After #138 and #139 , this PR brings some code improvements in order to be able to re-utilize all the metrics for Prometheus for any other monitoring tool.

It adds a micro-DSL to store these metrics and provide syntax helpers to build the existing ones easily. All the hardcoded metrics in the tests have been replaced by using these enhancements.