### PR TITLE
Adds *frees-rpc-testing* including *grpc-testing* dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,7 @@ lazy val async = project
 lazy val internal = project
   .in(file("modules/internal"))
   .dependsOn(common % "compile->compile;test->test")
+  .dependsOn(testing % "test->test")
   .settings(moduleName := "frees-rpc-internal")
   .settings(internalSettings)
 
@@ -24,6 +25,7 @@ lazy val client = project
   .dependsOn(common % "compile->compile;test->test")
   .dependsOn(internal)
   .dependsOn(async)
+  .dependsOn(testing % "test->test")
   .settings(moduleName := "frees-rpc-client-core")
   .settings(clientCoreSettings)
 
@@ -45,6 +47,7 @@ lazy val server = project
   .dependsOn(client % "test->test")
   .dependsOn(internal)
   .dependsOn(async)
+  .dependsOn(testing % "test->test")
   .settings(moduleName := "frees-rpc-server")
   .settings(serverSettings)
 
@@ -53,6 +56,7 @@ lazy val config = project
   .dependsOn(common % "test->test")
   .dependsOn(client % "compile->compile;test->test")
   .dependsOn(server % "compile->compile;test->test")
+  .dependsOn(testing % "test->test")
   .settings(moduleName := "frees-rpc-config")
   .settings(configSettings)
 
@@ -96,6 +100,11 @@ lazy val `dropwizard-client` = project
   .settings(moduleName := "frees-rpc-dropwizard-client")
   .settings(dropwizardSettings)
 
+lazy val testing = project
+  .in(file("modules/testing"))
+  .settings(moduleName := "frees-rpc-testing")
+  .settings(testingSettings)
+
 //////////////////////////
 //// MODULES REGISTRY ////
 //////////////////////////
@@ -114,7 +123,8 @@ lazy val allModules: Seq[ProjectReference] = Seq(
   `prometheus-client`,
   `prometheus-server`,
   `dropwizard-server`,
-  `dropwizard-client`
+  `dropwizard-client`,
+  testing
 )
 
 lazy val allModulesDeps: Seq[ClasspathDependency] =

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -59,16 +59,14 @@ object ProjectPlugin extends AutoPlugin {
         %%("monix"),
         %%("pbdirect", V.pbdirect),
         %%("avro4s", V.avro4s),
-        %("grpc-testing", V.grpc) % Test,
-        %%("scalamockScalatest")  % Test
+        %%("scalamockScalatest") % Test
       )
     )
 
     lazy val clientCoreSettings: Seq[Def.Setting[_]] = Seq(
       libraryDependencies ++= Seq(
         %%("frees-async-cats-effect", V.frees),
-        %("grpc-testing", V.grpc) % Test,
-        %%("scalamockScalatest")  % Test
+        %%("scalamockScalatest") % Test
       )
     )
 
@@ -89,15 +87,13 @@ object ProjectPlugin extends AutoPlugin {
         %%("frees-async-cats-effect", V.frees),
         %("grpc-core", V.grpc),
         %("grpc-netty", V.grpc),
-        %("grpc-testing", V.grpc) % Test,
-        %%("scalamockScalatest")  % Test
+        %%("scalamockScalatest") % Test
       )
     )
 
     lazy val configSettings = Seq(
       libraryDependencies ++= Seq(
-        %%("frees-config", V.frees),
-        %("grpc-testing", V.grpc) % Test
+        %%("frees-config", V.frees)
       )
     )
 
@@ -122,6 +118,12 @@ object ProjectPlugin extends AutoPlugin {
     lazy val dropwizardSettings: Seq[Def.Setting[_]] = Seq(
       libraryDependencies ++= Seq(
         "io.prometheus" % "simpleclient_dropwizard" % V.prometheus
+      )
+    )
+
+    lazy val testingSettings: Seq[Def.Setting[_]] = Seq(
+      libraryDependencies ++= Seq(
+        %("grpc-testing", V.grpc)
       )
     )
 


### PR DESCRIPTION
This PR adds a new sbt module (artifact `frees-rpc-testing`) to provide transitively the `grpc-testing` dependency. In this way, library users don't need to know which is the `gRPC` version underneath.