### PR TITLE
Monadic Server Start/RPC Calls/Stop in Tests

### DIFF
--- a/modules/dropwizard/client/src/test/scala/MonitorClientInterceptorTests.scala
+++ b/modules/dropwizard/client/src/test/scala/MonitorClientInterceptorTests.scala
@@ -19,7 +19,7 @@ package dropwizard
 package client
 
 import com.codahale.metrics.MetricRegistry
-import freestyle.rpc.prometheus.client.{BaseMonitorClientInterceptorTests, ClientRuntime}
+import freestyle.rpc.prometheus.client.{BaseMonitorClientInterceptorTests, InterceptorsRuntime}
 import freestyle.rpc.prometheus.shared.Configuration
 import io.prometheus.client.dropwizard.DropwizardExports
 
@@ -27,30 +27,30 @@ class MonitorClientInterceptorTests extends BaseMonitorClientInterceptorTests {
 
   override def name: String = "Dropwizard"
 
-  def defaultClientRuntime: ClientRuntime = {
+  def defaultClientRuntime: InterceptorsRuntime = {
 
     val metrics: MetricRegistry      = new MetricRegistry
     val configuration: Configuration = Configuration.defaultBasicMetrics
     configuration.collectorRegistry.register(new DropwizardExports(metrics))
 
-    ClientRuntime(configuration)
+    InterceptorsRuntime(configuration)
   }
 
-  def allMetricsClientRuntime: ClientRuntime = {
+  def allMetricsClientRuntime: InterceptorsRuntime = {
 
     val metrics: MetricRegistry      = new MetricRegistry
     val configuration: Configuration = Configuration.defaultAllMetrics
     configuration.collectorRegistry.register(new DropwizardExports(metrics))
 
-    ClientRuntime(configuration)
+    InterceptorsRuntime(configuration)
   }
 
-  def clientRuntimeWithNonDefaultBuckets(buckets: Vector[Double]): ClientRuntime = {
+  def clientRuntimeWithNonDefaultBuckets(buckets: Vector[Double]): InterceptorsRuntime = {
 
     val metrics: MetricRegistry      = new MetricRegistry
     val configuration: Configuration = Configuration.defaultAllMetrics.withLatencyBuckets(buckets)
     configuration.collectorRegistry.register(new DropwizardExports(metrics))
 
-    ClientRuntime(configuration)
+    InterceptorsRuntime(configuration)
   }
 }

--- a/modules/prometheus/client/src/test/scala/InterceptorsRuntime.scala
+++ b/modules/prometheus/client/src/test/scala/InterceptorsRuntime.scala
@@ -20,16 +20,21 @@ package client
 
 import freestyle.rpc.client._
 import freestyle.rpc.common.ConcurrentMonad
-import freestyle.rpc.prometheus.client.implicits.{createManagedChannelForPort, serverW}
 import freestyle.rpc.prometheus.shared.Configuration
 import freestyle.rpc.withouttagless.Utils._
 import freestyle.rpc.withouttagless.Utils.handlers.client.FreesRPCServiceClientHandler
 import io.prometheus.client.CollectorRegistry
 
-trait InterceptorsRuntime extends CommonUtils {
+case class InterceptorsRuntime(
+    configuration: Configuration,
+    cr: CollectorRegistry = new CollectorRegistry())
+    extends CommonUtils {
 
   import service._
   import handlers.server._
+  import handlers.client._
+  import freestyle.async.catsEffect.implicits._
+
   import freestyle.rpc.server._
   import freestyle.rpc.server.implicits._
 
@@ -45,19 +50,6 @@ trait InterceptorsRuntime extends CommonUtils {
 
   implicit lazy val freesRPCHandler: ServerRPCService[ConcurrentMonad] =
     new ServerRPCService[ConcurrentMonad]
-
-}
-
-object implicits extends InterceptorsRuntime
-
-case class ClientRuntime(
-    configuration: Configuration,
-    cr: CollectorRegistry = new CollectorRegistry()) {
-
-  import service._
-  import handlers.client._
-  import freestyle.rpc.client.implicits._
-  import freestyle.async.catsEffect.implicits._
 
   implicit val CR: CollectorRegistry = cr
 

--- a/modules/prometheus/client/src/test/scala/MonitorClientInterceptorTests.scala
+++ b/modules/prometheus/client/src/test/scala/MonitorClientInterceptorTests.scala
@@ -24,11 +24,13 @@ class MonitorClientInterceptorTests extends BaseMonitorClientInterceptorTests {
 
   override def name: String = "Prometheus"
 
-  def defaultClientRuntime: ClientRuntime = ClientRuntime(Configuration.defaultBasicMetrics)
+  def defaultClientRuntime: InterceptorsRuntime =
+    InterceptorsRuntime(Configuration.defaultBasicMetrics)
 
-  def allMetricsClientRuntime: ClientRuntime = ClientRuntime(Configuration.defaultAllMetrics)
+  def allMetricsClientRuntime: InterceptorsRuntime =
+    InterceptorsRuntime(Configuration.defaultAllMetrics)
 
-  def clientRuntimeWithNonDefaultBuckets(buckets: Vector[Double]): ClientRuntime =
-    ClientRuntime(Configuration.defaultAllMetrics.withLatencyBuckets(buckets))
+  def clientRuntimeWithNonDefaultBuckets(buckets: Vector[Double]): InterceptorsRuntime =
+    InterceptorsRuntime(Configuration.defaultAllMetrics.withLatencyBuckets(buckets))
 
 }


### PR DESCRIPTION
This PR enforces that all the metrics tests (for both server and client), sequentially does (for every test fragment):

* Start the server
* Request/s
* Stop the server

In this way, the random tests failures are gone after 12 successful builds in Travis (bearing in mind Scala 2.11 and Scala 2.12).