### PR TITLE
Releases *frees-rpc* 0.10.0

### DIFF
--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -18,7 +18,7 @@ object ProjectPlugin extends AutoPlugin {
 
     lazy val V = new {
       val avro4s: String     = "1.8.0"
-      val frees: String      = "0.6.1"
+      val frees: String      = "0.6.2"
       val grpc: String       = "1.9.0"
       val pbdirect: String   = "0.0.8"
       val prometheus: String = "0.1.0"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9.1-SNAPSHOT"
+version in ThisBuild := "0.10.0"


### PR DESCRIPTION
It also bumps up the freestyle version to `0.6.2`.