### PR TITLE
Try to fix the random test failure in client metrics

### DIFF
--- a/modules/common/src/test/scala/RpcBaseTestSuite.scala
+++ b/modules/common/src/test/scala/RpcBaseTestSuite.scala
@@ -23,8 +23,6 @@ import org.scalatest.{Matchers, OneInstancePerTest, WordSpec}
 
 trait RpcBaseTestSuite extends WordSpec with Matchers with OneInstancePerTest with MockFactory {
 
-  val sleepM: ConcurrentMonad[Unit] = delayM(Thread.sleep(500))
-
   trait Helpers {
 
     def runK[F[_], A, B](kleisli: Kleisli[F, A, B], v: A): F[B] =

--- a/modules/common/src/test/scala/common.scala
+++ b/modules/common/src/test/scala/common.scala
@@ -22,6 +22,6 @@ package object common {
 
   type ConcurrentMonad[A] = IO[A]
 
-  def delayM[A](a: A): ConcurrentMonad[A] = IO(a)
+  def suspendM[A](a: A): ConcurrentMonad[A] = IO(a)
 
 }

--- a/modules/prometheus/client/src/test/scala/BaseMonitorClientInterceptorTests.scala
+++ b/modules/prometheus/client/src/test/scala/BaseMonitorClientInterceptorTests.scala
@@ -62,13 +62,16 @@ abstract class BaseMonitorClientInterceptorTests extends RpcBaseTestSuite {
   private[this] def checkWithRetry(assertionF: () => Assertion)(
       step: Int = 0,
       maxRetries: Int = 10,
-      sleepMillis: Long = 500)(implicit CR: CollectorRegistry): Assertion =
+      sleepMillis: Long = 200)(implicit CR: CollectorRegistry): Assertion =
     try {
       assertionF()
     } catch {
       case e: TestFailedException =>
         if (step == maxRetries) throw e
-        else checkWithRetry(assertionF)(step + 1, maxRetries, sleepMillis)
+        else {
+          Thread.sleep(sleepMillis)
+          checkWithRetry(assertionF)(step + 1, maxRetries, sleepMillis)
+        }
     }
 
   s"MonitorClientInterceptor for $name" should {

--- a/modules/prometheus/client/src/test/scala/BaseMonitorClientInterceptorTests.scala
+++ b/modules/prometheus/client/src/test/scala/BaseMonitorClientInterceptorTests.scala
@@ -18,12 +18,16 @@ package freestyle.rpc
 package prometheus
 package client
 
-import cats.Applicative
 import freestyle.rpc.common._
 import freestyle.rpc.protocol.Utils.client.MyRPCClient
-import io.prometheus.client.Collector
+import io.prometheus.client.{Collector, CollectorRegistry}
 import freestyle.rpc.interceptors.metrics._
+import io.prometheus.client.Collector.MetricFamilySamples
+import org.scalatest.exceptions.TestFailedException
+import org.scalatest.Assertion
+import org.scalatest.matchers.{MatchResult, Matcher}
 
+import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 
 abstract class BaseMonitorClientInterceptorTests extends RpcBaseTestSuite {
@@ -37,6 +41,36 @@ abstract class BaseMonitorClientInterceptorTests extends RpcBaseTestSuite {
   def allMetricsClientRuntime: InterceptorsRuntime
   def clientRuntimeWithNonDefaultBuckets(buckets: Vector[Double]): InterceptorsRuntime
 
+  def beASampleMetric(
+      labels: List[String],
+      minValue: Double = 0d,
+      maxValue: Double = 1d): Matcher[Option[MetricFamilySamples.Sample]] =
+    new Matcher[Option[MetricFamilySamples.Sample]] {
+      def apply(maybe: Option[MetricFamilySamples.Sample]): MatchResult = MatchResult(
+        maybe.forall { s =>
+          s.value should be >= minValue
+          s.value should be <= maxValue
+          s.labelValues.asScala.toList.sorted shouldBe labels.sorted
+          s.value >= minValue && s.value <= maxValue && s.labelValues.asScala.toList.sorted == labels.sorted
+        },
+        "Incorrect metric",
+        "Valid metric"
+      )
+    }
+
+  @tailrec
+  private[this] def checkWithRetry(assertionF: () => Assertion)(
+      step: Int = 0,
+      maxRetries: Int = 10,
+      sleepMillis: Long = 500)(implicit CR: CollectorRegistry): Assertion =
+    try {
+      assertionF()
+    } catch {
+      case e: TestFailedException =>
+        if (step == maxRetries) throw e
+        else checkWithRetry(assertionF)(step + 1, maxRetries, sleepMillis)
+    }
+
   s"MonitorClientInterceptor for $name" should {
 
     "work for unary RPC metrics" in {
@@ -44,34 +78,28 @@ abstract class BaseMonitorClientInterceptorTests extends RpcBaseTestSuite {
       def clientProgram[F[_]](implicit APP: MyRPCClient[F]): F[C] =
         APP.u(a1.x, a1.y)
 
+      def check(implicit CR: CollectorRegistry): ConcurrentMonad[Assertion] = suspendM {
+        val startedTotal: Double = extractMetricValue(clientMetricRpcStarted)
+        startedTotal should be >= 0d
+        startedTotal should be <= 1d
+        findRecordedMetricOrThrow(clientMetricStreamMessagesReceived).samples shouldBe empty
+        findRecordedMetricOrThrow(clientMetricStreamMessagesSent).samples shouldBe empty
+
+        val handledSamples =
+          findRecordedMetricOrThrow(clientMetricRpcCompleted).samples.asScala.toList
+        handledSamples.size shouldBe 1
+        handledSamples.headOption should beASampleMetric(List("UNARY", "RPCService", "unary", "OK"))
+      }
+
       val clientRuntime: InterceptorsRuntime = defaultClientRuntime
       import clientRuntime._
 
       (for {
-        _ <- serverStart[ConcurrentMonad]
-        _ <- clientProgram[ConcurrentMonad]
-        _ <- serverStop[ConcurrentMonad]
-      } yield (): Unit).unsafeRunSync()
-
-      val startedTotal: Double = extractMetricValue(clientMetricRpcStarted)
-      startedTotal should be >= 0d
-      startedTotal should be <= 1d
-      findRecordedMetricOrThrow(clientMetricStreamMessagesReceived).samples shouldBe empty
-      findRecordedMetricOrThrow(clientMetricStreamMessagesSent).samples shouldBe empty
-
-      val handledSamples =
-        findRecordedMetricOrThrow(clientMetricRpcCompleted).samples.asScala.toList
-      handledSamples.size shouldBe 1
-      handledSamples.headOption.foreach { s =>
-        s.value should be >= 0d
-        s.value should be <= 1d
-
-        s.labelValues.asScala.toList should contain theSameElementsAs Vector(
-          "UNARY",
-          "RPCService",
-          "unary",
-          "OK")
-      }
+        _         <- serverStart[ConcurrentMonad]
+        _         <- clientProgram[ConcurrentMonad]
+        assertion <- check
+        _         <- serverStop[ConcurrentMonad]
+      } yield assertion).unsafeRunSync()
 
     }
 
@@ -86,55 +114,45 @@ abstract class BaseMonitorClientInterceptorTests extends RpcBaseTestSuite {
       val clientRuntime: InterceptorsRuntime = defaultClientRuntime
       import clientRuntime._
 
-      def check1[F[_]: Applicative] = {
-        Applicative[F].pure {
+      def check1(implicit CR: CollectorRegistry): ConcurrentMonad[Assertion] = suspendM {
 
-          val startedTotal: Double = extractMetricValue(clientMetricRpcStarted)
+        val startedTotal: Double = extractMetricValue(clientMetricRpcStarted)
 
-          startedTotal should be >= 0d
-          startedTotal should be <= 1d
+        startedTotal should be >= 0d
+        startedTotal should be <= 1d
 
-          val msgSentTotal: Double = extractMetricValue(clientMetricStreamMessagesSent)
-          msgSentTotal should be >= 0d
-          msgSentTotal should be <= 2d
+        val msgSentTotal: Double = extractMetricValue(clientMetricStreamMessagesSent)
+        msgSentTotal should be >= 0d
+        msgSentTotal should be <= 2d
 
-          findRecordedMetricOrThrow(clientMetricStreamMessagesReceived).samples shouldBe empty
-
-          (): Unit
-        }
+        checkWithRetry(() =>
+          findRecordedMetricOrThrow(clientMetricStreamMessagesReceived).samples shouldBe empty)()
       }
 
-      def check2[F[_]: Applicative] = {
-        Applicative[F].pure {
+      def check2(implicit CR: CollectorRegistry): ConcurrentMonad[Assertion] = suspendM {
 
-          val msgSentTotal2: Double = extractMetricValue(clientMetricStreamMessagesSent)
-          msgSentTotal2 should be >= 0d
-          msgSentTotal2 should be <= 3d
+        val msgSentTotal2: Double = extractMetricValue(clientMetricStreamMessagesSent)
+        msgSentTotal2 should be >= 0d
+        msgSentTotal2 should be <= 3d
 
+        def completedAssertion: Assertion = {
           val handledSamples =
             findRecordedMetricOrThrow(clientMetricRpcCompleted).samples.asScala.toList
           handledSamples.size shouldBe 1
-          handledSamples.headOption.foreach { s =>
-            s.value should be >= 0d
-            s.value should be <= 2d
-
-            s.labelValues.asScala.toList should contain theSameElementsAs Vector(
-              "CLIENT_STREAMING",
-              "RPCService",
-              "clientStreaming",
-              "OK")
-          }
+          handledSamples.headOption should beASampleMetric(
+            labels = List("CLIENT_STREAMING", "RPCService", "clientStreaming", "OK"),
+            maxValue = 2d)
         }
+
+        checkWithRetry(() => completedAssertion)()
       }
 
       (for {
         _ <- serverStart[ConcurrentMonad]
         _ <- clientProgram[ConcurrentMonad]
-        _ <- sleepM
-        _ <- check1[ConcurrentMonad]
+        _ <- check1
         _ <- clientProgram2[ConcurrentMonad]
-        _ <- sleepM
-        _ <- check2[ConcurrentMonad]
+        _ <- check2
         _ <- serverStop[ConcurrentMonad]
       } yield (): Unit).unsafeRunSync()
 
@@ -145,37 +163,32 @@ abstract class BaseMonitorClientInterceptorTests extends RpcBaseTestSuite {
       def clientProgram[F[_]](implicit APP: MyRPCClient[F]): F[List[C]] =
         APP.ss(a2.x, a2.y)
 
+      def check(implicit CR: CollectorRegistry): ConcurrentMonad[Assertion] = suspendM {
+        val startedTotal: Double     = extractMetricValue(clientMetricRpcStarted)
+        val msgReceivedTotal: Double = extractMetricValue(clientMetricStreamMessagesReceived)
+        findRecordedMetricOrThrow(clientMetricStreamMessagesSent).samples shouldBe empty
+
+        startedTotal should be >= 0d
+        startedTotal should be <= 1d
+        msgReceivedTotal should be >= 0d
+        msgReceivedTotal should be <= 2d
+
+        val handledSamples =
+          findRecordedMetricOrThrow(clientMetricRpcCompleted).samples.asScala.toList
+        handledSamples.size shouldBe 1
+        handledSamples.headOption should beASampleMetric(
+          List("SERVER_STREAMING", "RPCService", "serverStreaming", "OK"))
+      }
+
       val clientRuntime: InterceptorsRuntime = defaultClientRuntime
       import clientRuntime._
 
       (for {
-        _ <- serverStart[ConcurrentMonad]
-        _ <- clientProgram[ConcurrentMonad]
-        _ <- serverStop[ConcurrentMonad]
-      } yield (): Unit).unsafeRunSync()
-
-      val startedTotal: Double     = extractMetricValue(clientMetricRpcStarted)
-      val msgReceivedTotal: Double = extractMetricValue(clientMetricStreamMessagesReceived)
-      findRecordedMetricOrThrow(clientMetricStreamMessagesSent).samples shouldBe empty
-
-      startedTotal should be >= 0d
-      startedTotal should be <= 1d
-      msgReceivedTotal should be >= 0d
-      msgReceivedTotal should be <= 2d
-
-      val handledSamples =
-        findRecordedMetricOrThrow(clientMetricRpcCompleted).samples.asScala.toList
-      handledSamples.size shouldBe 1
-      handledSamples.headOption.foreach { s =>
-        s.value should be >= 0d
-        s.value should be <= 1d
-        s.labelValues.asScala.toList should contain theSameElementsAs Vector(
-          "SERVER_STREAMING",
-          "RPCService",
-          "serverStreaming",
-          "OK"
-        )
-      }
+        _         <- serverStart[ConcurrentMonad]
+        _         <- clientProgram[ConcurrentMonad]
+        assertion <- check
+        _         <- serverStop[ConcurrentMonad]
+      } yield assertion).unsafeRunSync()
 
     }
 
@@ -184,40 +197,36 @@ abstract class BaseMonitorClientInterceptorTests extends RpcBaseTestSuite {
       def clientProgram[F[_]](implicit APP: MyRPCClient[F]): F[E] =
         APP.bs(eList)
 
+      def check(implicit CR: CollectorRegistry): ConcurrentMonad[Assertion] = suspendM {
+        val startedTotal: Double     = extractMetricValue(clientMetricRpcStarted)
+        val msgReceivedTotal: Double = extractMetricValue(clientMetricStreamMessagesReceived)
+        val msgSentTotal: Double     = extractMetricValue(clientMetricStreamMessagesSent)
+
+        startedTotal should be >= 0d
+        startedTotal should be <= 1d
+        msgReceivedTotal should be >= 0d
+        msgReceivedTotal should be <= 4d
+        msgSentTotal should be >= 0d
+        msgSentTotal should be <= 2d
+
+        val handledSamples =
+          findRecordedMetricOrThrow(clientMetricRpcCompleted).samples.asScala.toList
+        handledSamples.size shouldBe 1
+        handledSamples.headOption should be
+
+        handledSamples.headOption should beASampleMetric(
+          List("BIDI_STREAMING", "RPCService", "biStreaming", "OK"))
+      }
+
       val clientRuntime: InterceptorsRuntime = defaultClientRuntime
       import clientRuntime._
 
       (for {
-        _ <- serverStart[ConcurrentMonad]
-        _ <- clientProgram[ConcurrentMonad]
-        _ <- serverStop[ConcurrentMonad]
-      } yield (): Unit).unsafeRunSync()
-
-      val startedTotal: Double     = extractMetricValue(clientMetricRpcStarted)
-      val msgReceivedTotal: Double = extractMetricValue(clientMetricStreamMessagesReceived)
-      val msgSentTotal: Double     = extractMetricValue(clientMetricStreamMessagesSent)
-
-      startedTotal should be >= 0d
-      startedTotal should be <= 1d
-      msgReceivedTotal should be >= 0d
-      msgReceivedTotal should be <= 4d
-      msgSentTotal should be >= 0d
-      msgSentTotal should be <= 2d
-
-      val handledSamples =
-        findRecordedMetricOrThrow(clientMetricRpcCompleted).samples.asScala.toList
-      handledSamples.size shouldBe 1
-      handledSamples.headOption.foreach { s =>
-        s.value should be >= 0d
-        s.value should be <= 1d
-
-        s.labelValues.asScala.toList should contain theSameElementsAs Vector(
-          "BIDI_STREAMING",
-          "RPCService",
-          "biStreaming",
-          "OK")
-      }
-
+        _         <- serverStart[ConcurrentMonad]
+        _         <- clientProgram[ConcurrentMonad]
+        assertion <- check
+        _         <- serverStop[ConcurrentMonad]
+      } yield assertion).unsafeRunSync()
     }
 
     "work when no histogram is enabled" in {
@@ -229,12 +238,11 @@ abstract class BaseMonitorClientInterceptorTests extends RpcBaseTestSuite {
       import clientRuntime._
 
       (for {
-        _ <- serverStart[ConcurrentMonad]
-        _ <- clientProgram[ConcurrentMonad]
-        _ <- serverStop[ConcurrentMonad]
-      } yield (): Unit).unsafeRunSync()
-
-      findRecordedMetric(clientMetricCompletedLatencySeconds) shouldBe None
+        _         <- serverStart[ConcurrentMonad]
+        _         <- clientProgram[ConcurrentMonad]
+        assertion <- suspendM(findRecordedMetric(clientMetricCompletedLatencySeconds) shouldBe None)
+        _         <- serverStop[ConcurrentMonad]
+      } yield assertion).unsafeRunSync()
 
     }
 
@@ -243,22 +251,23 @@ abstract class BaseMonitorClientInterceptorTests extends RpcBaseTestSuite {
       def clientProgram[F[_]](implicit APP: MyRPCClient[F]): F[C] =
         APP.u(a1.x, a1.y)
 
+      def check(implicit CR: CollectorRegistry): ConcurrentMonad[Assertion] = suspendM {
+        val metric: Option[Collector.MetricFamilySamples] =
+          findRecordedMetric(clientMetricCompletedLatencySeconds)
+
+        metric shouldBe defined
+        metric.fold(true)(_.samples.size > 0) shouldBe true
+      }
+
       val clientRuntime: InterceptorsRuntime = allMetricsClientRuntime
       import clientRuntime._
 
       (for {
-        _ <- serverStart[ConcurrentMonad]
-        _ <- clientProgram[ConcurrentMonad]
-        _ <- serverStop[ConcurrentMonad]
-      } yield (): Unit).unsafeRunSync()
-
-      val metric: Option[Collector.MetricFamilySamples] =
-        findRecordedMetric(clientMetricCompletedLatencySeconds)
-
-      metric shouldBe defined
-      metric.map { m =>
-        m.samples.size should be > 0
-      }
+        _         <- serverStart[ConcurrentMonad]
+        _         <- clientProgram[ConcurrentMonad]
+        assertion <- check
+        _         <- serverStop[ConcurrentMonad]
+      } yield assertion).unsafeRunSync()
 
     }
 
@@ -267,19 +276,23 @@ abstract class BaseMonitorClientInterceptorTests extends RpcBaseTestSuite {
       def clientProgram[F[_]](implicit APP: MyRPCClient[F]): F[C] =
         APP.u(a1.x, a1.y)
 
-      val buckets: Vector[Double]            = Vector[Double](0.1, 0.2)
+      val buckets: Vector[Double] = Vector[Double](0.1, 0.2)
+
+      def check(implicit CR: CollectorRegistry): ConcurrentMonad[Assertion] = suspendM {
+        countSamples(
+          clientMetricCompletedLatencySeconds,
+          "grpc_client_completed_latency_seconds_bucket") shouldBe (buckets.size + 1)
+      }
+
       val clientRuntime: InterceptorsRuntime = clientRuntimeWithNonDefaultBuckets(buckets)
       import clientRuntime._
 
       (for {
-        _ <- serverStart[ConcurrentMonad]
-        _ <- clientProgram[ConcurrentMonad]
-        _ <- serverStop[ConcurrentMonad]
-      } yield (): Unit).unsafeRunSync()
-
-      countSamples(
-        clientMetricCompletedLatencySeconds,
-        "grpc_client_completed_latency_seconds_bucket") shouldBe (buckets.size + 1)
+        _         <- serverStart[ConcurrentMonad]
+        _         <- clientProgram[ConcurrentMonad]
+        assertion <- check
+        _         <- serverStop[ConcurrentMonad]
+      } yield assertion).unsafeRunSync()
 
     }
 
@@ -291,19 +304,22 @@ abstract class BaseMonitorClientInterceptorTests extends RpcBaseTestSuite {
       def clientStreaming[F[_]](implicit APP: MyRPCClient[F]): F[D] =
         APP.cs(cList, i)
 
+      def check(implicit CR: CollectorRegistry): ConcurrentMonad[Assertion] = suspendM {
+        findRecordedMetricOrThrow(clientMetricRpcStarted).samples.size() shouldBe 2
+        checkWithRetry(
+          () => findRecordedMetricOrThrow(clientMetricRpcCompleted).samples.size() shouldBe 2)()
+      }
+
       val clientRuntime: InterceptorsRuntime = defaultClientRuntime
       import clientRuntime._
 
       (for {
-        _ <- serverStart[ConcurrentMonad]
-        _ <- unary[ConcurrentMonad]
-        _ <- clientStreaming[ConcurrentMonad]
-        _ <- sleepM
-        _ <- serverStop[ConcurrentMonad]
-      } yield (): Unit).unsafeRunSync()
-
-      findRecordedMetricOrThrow(clientMetricRpcStarted).samples.size() shouldBe 2
-      findRecordedMetricOrThrow(clientMetricRpcCompleted).samples.size() shouldBe 2
+        _         <- serverStart[ConcurrentMonad]
+        _         <- unary[ConcurrentMonad]
+        _         <- clientStreaming[ConcurrentMonad]
+        assertion <- check
+        _         <- serverStop[ConcurrentMonad]
+      } yield assertion).unsafeRunSync()
 
     }
 


### PR DESCRIPTION
Fixes the random test failure by retrying the *completed* metrics check until a max retry is reached or the check pass.