### PR TITLE
Change implicit StreamObserver conversions to syntax

### DIFF
--- a/modules/internal/src/main/scala/client/package.scala
+++ b/modules/internal/src/main/scala/client/package.scala
@@ -36,7 +36,7 @@ package object client {
         ClientCalls.asyncServerStreamingCall(
           channel.newCall[Req, Res](descriptor, options),
           request,
-          subscriber
+          subscriber.toStreamObserver
         )
       }
     }

--- a/modules/internal/src/main/scala/server/package.scala
+++ b/modules/internal/src/main/scala/server/package.scala
@@ -17,6 +17,7 @@
 package freestyle.rpc
 package internal
 
+import io.grpc.stub.StreamObserver
 import monix.execution.{Ack, Scheduler}
 import monix.reactive.{Observable, Observer, Pipe}
 import monix.reactive.observers.Subscriber
@@ -40,5 +41,13 @@ package object server {
       override def onComplete(): Unit              = in.onComplete()
       override def onNext(value: Req): Future[Ack] = in.onNext(value)
     }
+
+  import freestyle.rpc.internal.converters._
+
+  private[server] def transformStreamObserver[Req, Res](
+      transformer: Observable[Req] => Observable[Res],
+      responseObserver: StreamObserver[Res]
+  )(implicit S: Scheduler): StreamObserver[Req] =
+    transform(transformer, responseObserver.toSubscriber).toStreamObserver
 
 }


### PR DESCRIPTION
Small `internal` cleanup

- Conversions between `StreamObserver` and Monix / reactive streams `Subscriber`s are now syntax methods instead of implicit conversions.
- Introduce `transformStreamObserver`.