### PR TITLE
Add non request statements to `Client`

### DIFF
--- a/docs/src/main/tut/README.md
+++ b/docs/src/main/tut/README.md
@@ -347,7 +347,7 @@ object service {
      */
     @rpc(Protobuf)
     @stream[ResponseStreaming.type]
-    def lotsOfReplies(request: HelloRequest): F[Observable[HelloResponse]]
+    def lotsOfReplies(request: HelloRequest): Observable[HelloResponse]
 
     /**
      * Client streaming RPCs where the client writes a sequence of messages and sends them to the server,
@@ -377,7 +377,7 @@ object service {
      */
     @rpc(Protobuf)
     @stream[BidirectionalStreaming.type]
-    def bidiHello(request: Observable[HelloRequest]): F[Observable[HelloResponse]]
+    def bidiHello(request: Observable[HelloRequest]): Observable[HelloResponse]
 
   }
 
@@ -483,8 +483,8 @@ class ServiceHandler[F[_]: Async](implicit S: Scheduler) extends Greeter[F] {
   override def sayHello(request: HelloRequest): F[HelloResponse] =
     HelloResponse(reply = "Good bye!").pure
 
-  override def lotsOfReplies(request: HelloRequest): F[Observable[HelloResponse]] =
-    dummyObservableResponse.pure
+  override def lotsOfReplies(request: HelloRequest): Observable[HelloResponse] =
+    dummyObservableResponse
 
   override def lotsOfGreetings(request: Observable[HelloRequest]): F[HelloResponse] =
     request
@@ -499,7 +499,7 @@ class ServiceHandler[F[_]: Async](implicit S: Scheduler) extends Greeter[F] {
       .map(_._2)
       .to[F]
 
-  override def bidiHello(request: Observable[HelloRequest]): F[Observable[HelloResponse]] =
+  override def bidiHello(request: Observable[HelloRequest]): Observable[HelloResponse] =
     request
       .flatMap { request: HelloRequest =>
         println(s"Saving $request...")
@@ -508,7 +508,6 @@ class ServiceHandler[F[_]: Async](implicit S: Scheduler) extends Greeter[F] {
       .onErrorHandle { e =>
         throw e
       }
-      .pure
 }
 ```
 

--- a/modules/server/src/test/scala/protocol/RPCTests.scala
+++ b/modules/server/src/test/scala/protocol/RPCTests.scala
@@ -184,6 +184,14 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
 
     }
 
+    "be able to have non request methods" in {
+
+      def clientProgram[F[_]: cats.Functor](implicit client: service.RPCService.Client[F]): F[Int] =
+        client.sumA
+
+      clientProgram[ConcurrentMonad].unsafeRunSync() shouldBe 3000
+    }
+
   }
 
   "frees-rpc client with compression" should {

--- a/modules/server/src/test/scala/protocol/Utils.scala
+++ b/modules/server/src/test/scala/protocol/Utils.scala
@@ -95,6 +95,9 @@ object Utils extends CommonUtils {
 
       @rpc(Protobuf, Gzip)
       def scopeCompressed(empty: Empty.type): F[External]
+
+      def sumA(implicit F: cats.Functor[F]): F[Int] =
+        F.map(emptyParamResponse(Empty))(a => a.x + a.y)
     }
 
   }


### PR DESCRIPTION
This would allow for example to add helper methods to the `Client` which do some conversion from/to the RPC messages.