### PR TITLE
Readd support for companion objects

### DIFF
--- a/modules/server/src/test/scala/fs2/Utils.scala
+++ b/modules/server/src/test/scala/fs2/Utils.scala
@@ -59,6 +59,11 @@ object Utils extends CommonUtils {
 
     }
 
+    object RPCService {
+      // this companion object is here to make sure @service supports
+      // companion objects
+    }
+
   }
 
   object handlers {


### PR DESCRIPTION
This brings back support for `@service` traits and abstract classes with an existing companion object.