### PR TITLE
Merge sbt-freestyle-protogen into freestyle-rpc codebase, and update @rpc processing to handle latest `freestyle-rpc syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ before_install:
 
 script:
 - sbt ++$TRAVIS_SCALA_VERSION orgScriptCI
+- sbt ++$TRAVIS_SCALA_VERSION scripted
 
 after_success:
 - bash <(curl -s https://codecov.io/bash) -t 5b75b318-ab71-4fbc-9203-bfa7765cdbdc

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,16 +32,24 @@ before_install:
 
 script:
 - sbt ++$TRAVIS_SCALA_VERSION orgScriptCI
-- sbt ++$TRAVIS_SCALA_VERSION scripted
 
-after_success:
-- bash <(curl -s https://codecov.io/bash) -t 5b75b318-ab71-4fbc-9203-bfa7765cdbdc
+stages:
+- test
+- plugin
+- deploy
 
 jobs:
   include:
+    - stage: plugin
+      scala: 2.12.4
+      script:
+        - sbt ++$TRAVIS_SCALA_VERSION idlgen-core/test
+        - sbt ++$TRAVIS_SCALA_VERSION idlgen-sbt/test
+        - sbt ++$TRAVIS_SCALA_VERSION publishLocal idlgen-sbt/publishLocal idlgen-sbt/scripted
     - stage: deploy
       scala: 2.12.4
       script:
+        - bash <(curl -s https://codecov.io/bash) -t 5b75b318-ab71-4fbc-9203-bfa7765cdbdc
         - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then
             if grep -q "SNAPSHOT" version.sbt; then
               sbt ++$TRAVIS_SCALA_VERSION publish;
@@ -52,6 +60,7 @@ jobs:
               git checkout master;
               git pull origin master;
               sbt release;
+              sbt idlgen-sbt/release;
               sbt depUpdateDependencyIssues;
             fi
           fi

--- a/build.sbt
+++ b/build.sbt
@@ -104,6 +104,22 @@ lazy val ssl = project
   .settings(moduleName := "frees-rpc-netty-ssl")
   .settings(nettySslSettings)
 
+lazy val `idlgen-core` = project
+  .in(file("modules/idlgen/core"))
+  .dependsOn(internal)
+  .dependsOn(client % "test->test")
+  .settings(moduleName := "frees-rpc-idlgen-core")
+
+lazy val `idlgen-sbt` = project
+  .in(file("modules/idlgen/plugin"))
+  .dependsOn(`idlgen-core` % "compile->compile;test->test")
+  .settings(moduleName := "frees-rpc-sbt-idlgen")
+  .settings(sbtPluginSettings)
+  .settings(sbtPlugin := true)
+  .enablePlugins(BuildInfoPlugin)
+  .settings(buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion))
+  .settings(buildInfoPackage := "freestyle.rpc.idlgen")
+
 //////////////////////////
 //// MODULES REGISTRY ////
 //////////////////////////
@@ -123,7 +139,9 @@ lazy val allModules: Seq[ProjectReference] = Seq(
   `dropwizard-server`,
   `dropwizard-client`,
   testing,
-  ssl
+  ssl,
+  `idlgen-core`,
+  `idlgen-sbt`
 )
 
 lazy val allModulesDeps: Seq[ClasspathDependency] =

--- a/build.sbt
+++ b/build.sbt
@@ -112,14 +112,15 @@ lazy val `idlgen-core` = project
 
 lazy val `idlgen-sbt` = project
   .in(file("modules/idlgen/plugin"))
+  .aggregate(`idlgen-core`)
   .dependsOn(`idlgen-core` % "compile->compile;test->test")
   .settings(moduleName := "frees-rpc-sbt-idlgen")
   .settings(sbtPluginSettings)
   .settings(sbtPlugin := true)
+  .settings(crossScalaVersions := Seq(scalaVersion.value)) // org.scala-sbt:scripted-plugin not available in 2.11 for recent sbt
   .enablePlugins(BuildInfoPlugin)
   .settings(buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion))
   .settings(buildInfoPackage := "freestyle.rpc.idlgen")
-  .settings(crossScalaVersions := Seq(scalaVersion.value))
 
 //////////////////////////
 //// MODULES REGISTRY ////

--- a/build.sbt
+++ b/build.sbt
@@ -119,6 +119,7 @@ lazy val `idlgen-sbt` = project
   .enablePlugins(BuildInfoPlugin)
   .settings(buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion))
   .settings(buildInfoPackage := "freestyle.rpc.idlgen")
+  .settings(crossScalaVersions := Seq(scalaVersion.value))
 
 //////////////////////////
 //// MODULES REGISTRY ////

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import sbtorgpolicies.model.scalac
+
 pgpPassphrase := Some(getEnvVar("PGP_PASSPHRASE").getOrElse("").toCharArray)
 pgpPublicRing := file(s"$gpgFolder/pubring.gpg")
 pgpSecretRing := file(s"$gpgFolder/secring.gpg")
@@ -6,6 +8,7 @@ lazy val common = project
   .in(file("modules/common"))
   .settings(moduleName := "frees-rpc-common")
   .settings(commonSettings)
+  .disablePlugins(ScriptedPlugin)
 
 lazy val internal = project
   .in(file("modules/internal"))
@@ -13,6 +16,7 @@ lazy val internal = project
   .dependsOn(testing % "test->test")
   .settings(moduleName := "frees-rpc-internal")
   .settings(internalSettings)
+  .disablePlugins(ScriptedPlugin)
 
 lazy val client = project
   .in(file("modules/client"))
@@ -21,18 +25,21 @@ lazy val client = project
   .dependsOn(testing % "test->test")
   .settings(moduleName := "frees-rpc-client-core")
   .settings(clientCoreSettings)
+  .disablePlugins(ScriptedPlugin)
 
 lazy val `client-netty` = project
   .in(file("modules/client-netty"))
   .dependsOn(client % "compile->compile;test->test")
   .settings(moduleName := "frees-rpc-client-netty")
   .settings(clientNettySettings)
+  .disablePlugins(ScriptedPlugin)
 
 lazy val `client-okhttp` = project
   .in(file("modules/client-okhttp"))
   .dependsOn(client % "compile->compile;test->test")
   .settings(moduleName := "frees-rpc-client-okhttp")
   .settings(clientOkHttpSettings)
+  .disablePlugins(ScriptedPlugin)
 
 lazy val server = project
   .in(file("modules/server"))
@@ -42,6 +49,7 @@ lazy val server = project
   .dependsOn(testing % "test->test")
   .settings(moduleName := "frees-rpc-server")
   .settings(serverSettings)
+  .disablePlugins(ScriptedPlugin)
 
 lazy val config = project
   .in(file("modules/config"))
@@ -51,23 +59,27 @@ lazy val config = project
   .dependsOn(testing % "test->test")
   .settings(moduleName := "frees-rpc-config")
   .settings(configSettings)
+  .disablePlugins(ScriptedPlugin)
 
 lazy val interceptors = project
   .in(file("modules/interceptors"))
   .settings(moduleName := "frees-rpc-interceptors")
   .settings(interceptorsSettings)
+  .disablePlugins(ScriptedPlugin)
 
 lazy val `prometheus-shared` = project
   .in(file("modules/prometheus/shared"))
   .dependsOn(interceptors % "compile->compile;test->test")
   .settings(moduleName := "frees-rpc-prometheus-shared")
   .settings(prometheusSettings)
+  .disablePlugins(ScriptedPlugin)
 
 lazy val `prometheus-server` = project
   .in(file("modules/prometheus/server"))
   .dependsOn(`prometheus-shared` % "compile->compile;test->test")
   .dependsOn(server % "compile->compile;test->test")
   .settings(moduleName := "frees-rpc-prometheus-server")
+  .disablePlugins(ScriptedPlugin)
 
 lazy val `prometheus-client` = project
   .in(file("modules/prometheus/client"))
@@ -76,6 +88,7 @@ lazy val `prometheus-client` = project
   .dependsOn(server % "test->test")
   .settings(moduleName := "frees-rpc-prometheus-client")
   .settings(prometheusClientSettings)
+  .disablePlugins(ScriptedPlugin)
 
 lazy val `dropwizard-server` = project
   .in(file("modules/dropwizard/server"))
@@ -83,6 +96,7 @@ lazy val `dropwizard-server` = project
   .dependsOn(server % "compile->compile;test->test")
   .settings(moduleName := "frees-rpc-dropwizard-server")
   .settings(dropwizardSettings)
+  .disablePlugins(ScriptedPlugin)
 
 lazy val `dropwizard-client` = project
   .in(file("modules/dropwizard/client"))
@@ -91,11 +105,13 @@ lazy val `dropwizard-client` = project
   .dependsOn(server % "test->test")
   .settings(moduleName := "frees-rpc-dropwizard-client")
   .settings(dropwizardSettings)
+  .disablePlugins(ScriptedPlugin)
 
 lazy val testing = project
   .in(file("modules/testing"))
   .settings(moduleName := "frees-rpc-testing")
   .settings(testingSettings)
+  .disablePlugins(ScriptedPlugin)
 
 lazy val ssl = project
   .in(file("modules/ssl"))
@@ -103,21 +119,22 @@ lazy val ssl = project
   .dependsOn(`client-netty` % "compile->compile;test->test")
   .settings(moduleName := "frees-rpc-netty-ssl")
   .settings(nettySslSettings)
+  .disablePlugins(ScriptedPlugin)
 
 lazy val `idlgen-core` = project
   .in(file("modules/idlgen/core"))
   .dependsOn(internal)
   .dependsOn(client % "test->test")
   .settings(moduleName := "frees-rpc-idlgen-core")
+  .disablePlugins(ScriptedPlugin)
 
 lazy val `idlgen-sbt` = project
   .in(file("modules/idlgen/plugin"))
-  .aggregate(`idlgen-core`)
-  .dependsOn(`idlgen-core` % "compile->compile;test->test")
-  .settings(moduleName := "frees-rpc-sbt-idlgen")
-  .settings(sbtPluginSettings)
+  .dependsOn(`idlgen-core`)
+  .settings(moduleName := "sbt-frees-rpc-idlgen")
   .settings(sbtPlugin := true)
-  .settings(crossScalaVersions := Seq(scalaVersion.value)) // org.scala-sbt:scripted-plugin not available in 2.11 for recent sbt
+  .settings(crossScalaVersions := Seq(scalac.`2.12`))
+  .settings(sbtPluginSettings: _*)
   .enablePlugins(BuildInfoPlugin)
   .settings(buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion))
   .settings(buildInfoPackage := "freestyle.rpc.idlgen")
@@ -142,8 +159,7 @@ lazy val allModules: Seq[ProjectReference] = Seq(
   `dropwizard-client`,
   testing,
   ssl,
-  `idlgen-core`,
-  `idlgen-sbt`
+  `idlgen-core`
 )
 
 lazy val allModulesDeps: Seq[ClasspathDependency] =
@@ -155,6 +171,7 @@ lazy val root = project
   .settings(noPublishSettings)
   .aggregate(allModules: _*)
   .dependsOn(allModulesDeps: _*)
+  .disablePlugins(ScriptedPlugin)
 
 lazy val docs = project
   .in(file("docs"))

--- a/docs/src/main/tut/README.md
+++ b/docs/src/main/tut/README.md
@@ -416,6 +416,8 @@ addSbtPlugin("io.frees" % "frees-rpc-sbt-idlgen" % "0.11.1")
 ```
 [comment]: # (End Replace)
 
+Note that the plugin is only available for Scala 2.12.
+
 ### Plugin Settings
 
 There are a couple key settings that can be configured according to various needs:

--- a/docs/src/main/tut/README.md
+++ b/docs/src/main/tut/README.md
@@ -412,7 +412,7 @@ Add the following line to _project/plugins.sbt_:
 
 [comment]: # (Start Replace)
 ```scala
-addSbtPlugin("io.frees" % "frees-rpc-sbt-idlgen" % "0.11.1")
+addSbtPlugin("io.frees" % "sbt-frees-rpc-idlgen" % "0.11.1")
 ```
 [comment]: # (End Replace)
 

--- a/docs/src/main/tut/README.md
+++ b/docs/src/main/tut/README.md
@@ -113,6 +113,9 @@ libraryDependencies += "io.frees" %% "frees-rpc-dropwizard-client" % "0.11.1"
 
 // optional - for the communication between server and client by using SSL/TLS.
 libraryDependencies += "io.frees" %% "frees-rpc-netty-ssl" % "0.11.1"
+
+// optional - for .proto file generation.
+libraryDependencies += "io.frees" %% "frees-rpc-sbt-idlgen" % "0.11.1"
 ```
 
 [comment]: # (End Replace)
@@ -152,7 +155,7 @@ Likewise, you can define [gRPC] services in your proto files, with RPC method pa
 // The greeter service definition.
 service Greeter {
   // Sends a greeting
-  rpc SayHello (HelloRequest) returns (HelloReply) {}
+  rpc sayHello (HelloRequest) returns (HelloReply) {}
 }
 
 // The request message containing the user's name.
@@ -201,7 +204,7 @@ import freestyle.rpc.protocol._
 case class Person(name: String, id: Int, has_ponycopter: Boolean)
 ```
 
-As we can see, it’s quite simple since it’s just a Scala case class preceded by the `@message` annotation (`@message` is optional though and used exclusively by [sbt-freestyle-protogen](https://github.com/frees-io/sbt-freestyle-protogen)):
+As we can see, it’s quite simple since it’s just a Scala case class preceded by the `@message` annotation (`@message` is optional though and used exclusively by `protoGen`):
 
 By the same token, let’s see now how the `Greeter` service would be translated to the [frees-rpc] style (in your `.scala` file):
 
@@ -281,13 +284,13 @@ object protocol {
      * @param request Say Hello Request.
      * @return HelloReply.
      */
-    @rpc(Protobuf) def sayHello(request: HelloRequest): F[HelloReply]
+    @rpc(Protobuf) def SayHello(request: HelloRequest): F[HelloReply]
 
-    @rpc(Protobuf) def emptyResponse(request: HelloRequest): F[Empty.type]
+    @rpc(Protobuf) def EmptyResponse(request: HelloRequest): F[Empty.type]
 
-    @rpc(Protobuf) def emptyRequest(request: Empty.type): F[HelloReply]
+    @rpc(Protobuf) def EmptyRequest(request: Empty.type): F[HelloReply]
 
-    @rpc(Protobuf) def emptyRequestRespose(request: Empty.type): F[Empty.type]
+    @rpc(Protobuf) def EmptyRequestRespose(request: Empty.type): F[Empty.type]
   }
 }
 ```
@@ -404,15 +407,17 @@ The code might be explanatory by itself but let's review the different services 
 
 Before entering implementation details, we mentioned that the [frees-rpc] ecosystem brings the ability to generate `.proto` files from the Scala definition, in order to maintain compatibility with other languages and systems outside of Scala.
 
-This responsibility relies on [sbt-freestyle-protogen](https://github.com/frees-io/sbt-freestyle-protogen), an Sbt plugin to generate `.proto` files from the [frees-rpc] service definitions.
+This responsibility relies on `protoGen`, an Sbt plugin to generate `.proto` files from the [frees-rpc] service definitions.
 
 ### Plugin Installation
 
 Add the following line to _project/plugins.sbt_:
 
+[comment]: # (Start Replace)
 ```scala
-addSbtPlugin("io.frees" % "sbt-frees-protogen" % "0.0.14")
+addSbtPlugin("io.frees" % "frees-rpc-sbt-idlgen" % "0.11.1")
 ```
+[comment]: # (End Replace)
 
 ### Plugin Settings
 
@@ -435,7 +440,7 @@ Using the example above, the result would be placed at `/src/main/proto/service.
 
 ```
 // This file has been automatically generated for use by
-// sbt-frees-protogen plugin, from freestyle-rpc service definitions
+// the protoGen plugin, from freestyle-rpc service definitions
 
 syntax = "proto3";
 

--- a/docs/src/main/tut/README.md
+++ b/docs/src/main/tut/README.md
@@ -113,9 +113,6 @@ libraryDependencies += "io.frees" %% "frees-rpc-dropwizard-client" % "0.11.1"
 
 // optional - for the communication between server and client by using SSL/TLS.
 libraryDependencies += "io.frees" %% "frees-rpc-netty-ssl" % "0.11.1"
-
-// optional - for .proto file generation.
-libraryDependencies += "io.frees" %% "frees-rpc-sbt-idlgen" % "0.11.1"
 ```
 
 [comment]: # (End Replace)

--- a/modules/idlgen/core/src/main/scala/ProtoCodeGen.scala
+++ b/modules/idlgen/core/src/main/scala/ProtoCodeGen.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc.idlgen.protobuf
+
+import cats.implicits._
+import freestyle.rpc.idlgen.protobuf.encoders._
+import freestyle.rpc.idlgen.protobuf.model._
+import freestyle.rpc.idlgen.protobuf.processors._
+import java.io.File
+import java.nio.charset.Charset
+import java.nio.file._
+import scala.util._
+
+object ProtoCodeGen {
+
+  def main(args: Array[String]): Unit = {
+    args.toList match {
+      case input :: output :: Nil =>
+        generate(new File(input), new File(output)) foreach {
+          case Some((file, contents)) =>
+            Files.write(
+              file.toPath,
+              contents.getBytes(Charset.forName("UTF-8"))
+            )
+          case None =>
+        }
+      case _ =>
+        throw new IllegalArgumentException(s"Expected 2 $args with input and output directories")
+    }
+  }
+
+  def generate(input: File, output: File): Seq[Option[(File, String)]] = {
+    def allScalaFiles(f: File): List[File] = {
+      val children   = f.listFiles
+      val scalaFiles = children.filter(f => """.*\.scala$""".r.findFirstIn(f.getName).isDefined)
+      (scalaFiles ++ children.filter(_.isDirectory).flatMap(allScalaFiles)).toList
+    }
+    if (input.isDirectory && output.isDirectory) {
+      allScalaFiles(input)
+        .map { inputFile =>
+          ProtoAnnotationsProcessor[Try]
+            .process(inputFile)
+            .map {
+              case pd if pd.options.nonEmpty || pd.messages.nonEmpty || pd.services.nonEmpty =>
+                val protoContents = ProtoEncoder[ProtoDefinitions].encode(pd)
+                val outputFile =
+                  new File(output.toPath + "/" + inputFile.getName.replaceAll(".scala", ".proto"))
+                println(s"""
+                           |
+                           |Scala File: $inputFile
+                           |Proto File: $outputFile
+                           |----------------------------------
+                           |$protoContents
+                           |----------------------------------
+                           |""".stripMargin)
+                Some((outputFile, protoContents))
+              case _ =>
+                None
+            }
+        }
+        .map {
+          case Success(s) => s
+          case Failure(t) => throw t
+        }
+    } else {
+      throw new IllegalArgumentException(s"Expected $input and $output to be directories")
+    }
+  }
+
+}

--- a/modules/idlgen/core/src/main/scala/converters.scala
+++ b/modules/idlgen/core/src/main/scala/converters.scala
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc.idlgen.protobuf
+
+import freestyle.rpc.idlgen.protobuf.model._
+import freestyle.rpc.internal.ServiceAlg
+import scala.meta.Defn._
+import scala.meta._
+
+object converters {
+
+  trait ScalaMetaSource2ProtoDefinitions {
+    def convert(s: Source): ProtoDefinitions
+  }
+
+  class DefaultScalaMetaSource2ProtoDefinitions(
+      implicit OC: ScalaMetaObject2ProtoOptions,
+      MC: ScalaMetaClass2ProtoMessage,
+      SC: ScalaMetaTrait2ProtoService)
+      extends ScalaMetaSource2ProtoDefinitions {
+
+    override def convert(s: Source): ProtoDefinitions = ProtoDefinitions(
+      options = optionDirectives(s).toList.flatMap(OC.convert),
+      messages = messageClasses(s).map(MC.convert).toList,
+      services = serviceClasses(s).map(SC.convert).toList
+    )
+
+    private[this] def optionDirectives(source: Source): Seq[Object] = source.collect {
+      case o: Object /*if o.hasMod(mod"@option")*/ => o
+    }
+
+    private[this] def messageClasses(source: Source): Seq[Class] = source.collect {
+      case c: Class if c.mods.exists { case mod"@message" => true; case _ => false } => c
+    }
+
+    private[this] def serviceClasses(source: Source): Seq[Trait] = source.collect {
+      case t: Trait if t.mods.exists { case mod"@service" => true; case _ => false } => t
+    }
+  }
+
+  object ScalaMetaSource2ProtoDefinitions {
+    implicit def defaultSourceToProtoDefinitions(
+        implicit OC: ScalaMetaObject2ProtoOptions,
+        MC: ScalaMetaClass2ProtoMessage,
+        SC: ScalaMetaTrait2ProtoService): ScalaMetaSource2ProtoDefinitions =
+      new DefaultScalaMetaSource2ProtoDefinitions
+  }
+
+  trait ScalaMetaClass2ProtoMessage {
+    def convert(c: Class): ProtoMessage
+  }
+
+  object ScalaMetaClass2ProtoMessage {
+    implicit def defaultClass2MessageConverter(
+        implicit PC: ScalaMetaParam2ProtoMessageField): ScalaMetaClass2ProtoMessage =
+      new ScalaMetaClass2ProtoMessage {
+        override def convert(c: Class): ProtoMessage = ProtoMessage(
+          name = c.name.value,
+          fields = c.ctor.paramss.flatten.zipWithIndex.map {
+            case (p, t) => PC.convert(p, t + 1, None)
+          }.toList
+        )
+      }
+  }
+
+  trait ScalaMetaParam2ProtoMessageField {
+    def convert(p: Term.Param, tag: Int, mod: Option[ProtoFieldMod]): ProtoMessageField
+  }
+
+  object ScalaMetaParam2ProtoMessageField {
+    implicit def defaultParam2ProtoMessageField: ScalaMetaParam2ProtoMessageField =
+      new ScalaMetaParam2ProtoMessageField {
+        override def convert(
+            p: Term.Param,
+            tag: Int,
+            mod: Option[ProtoFieldMod] = None): ProtoMessageField = p match {
+          case param"..$mods $paramname: Double = $expropt" =>
+            ProtoDouble(mod = mod, name = paramname.value, tag = tag)
+          case param"..$mods $paramname: Float = $expropt" =>
+            ProtoFloat(mod = mod, name = paramname.value, tag = tag)
+          case param"..$mods $paramname: Long = $expropt" =>
+            ProtoInt64(mod = mod, name = paramname.value, tag = tag)
+          case param"..$mods $paramname: Boolean = $expropt" =>
+            ProtoBool(mod = mod, name = paramname.value, tag = tag)
+          case param"..$mods $paramname: Int = $expropt" =>
+            ProtoInt32(mod = mod, name = paramname.value, tag = tag)
+          case param"..$mods $paramname: String = $expropt" =>
+            ProtoString(mod = mod, name = paramname.value, tag = tag)
+          case param"..$mods $paramname: Array[Byte] = $expropt" =>
+            ProtoBytes(mod = mod, name = paramname.value, tag = tag)
+          case param"..$mods $paramname: List[$tpe] = $expropt" =>
+            convert(param"..$mods $paramname: $tpe = $expropt", tag, Some(Repeated))
+          case param"..$mods $paramname: Option[$tpe] = $expropt" =>
+            convert(param"..$mods $paramname: $tpe = $expropt", tag, None)
+          case param"..$mods $paramname: $tpe = $expr" =>
+            val ntpe = tpe match {
+              case Some(tt) => tt.toString
+              case _        => tpe.toString
+            }
+            ProtoCustomType(mod = mod, name = paramname.value, tag = tag, id = ntpe)
+        }
+      }
+  }
+
+  trait ScalaMetaTrait2ProtoService {
+    def convert(t: Trait): ProtoService
+  }
+
+  object ScalaMetaTrait2ProtoService {
+    implicit def defaultTrait2ServiceConverter: ScalaMetaTrait2ProtoService =
+      new ScalaMetaTrait2ProtoService {
+        override def convert(t: Trait): ProtoService =
+          ProtoService(
+            t.name.value,
+            ServiceAlg(t).requests.map(
+              req =>
+                ProtoServiceField(
+                  req.name.toString,
+                  req.requestType.toString,
+                  req.responseType.toString,
+                  req.streamingType))
+          )
+      }
+  }
+
+  trait ScalaMetaObject2ProtoOptions {
+    def convert(o: Object): List[ProtoOption]
+  }
+
+  object ScalaMetaObject2ProtoOptions {
+    implicit def defaultObject2Options: ScalaMetaObject2ProtoOptions =
+      new ScalaMetaObject2ProtoOptions {
+        override def convert(o: Object): List[ProtoOption] = {
+          o.mods.collect {
+            case Mod.Annot(
+                Term.Apply(
+                  Ctor.Ref.Name("option"),
+                  Seq(
+                    Term.Arg.Named(Term.Name("name"), Lit.String(name)),
+                    Term.Arg.Named(Term.Name("value"), Lit.String(value)),
+                    Term.Arg.Named(Term.Name("quote"), Lit.Boolean(quote))))) =>
+              ProtoOption(name, value, quote)
+          }.toList
+        }
+      }
+  }
+
+}

--- a/modules/idlgen/core/src/main/scala/encoders.scala
+++ b/modules/idlgen/core/src/main/scala/encoders.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc.idlgen.protobuf
+
+import freestyle.rpc.idlgen.protobuf.model._
+import freestyle.rpc.protocol._
+import simulacrum.typeclass
+
+object encoders {
+
+  @typeclass
+  trait ProtoEncoder[A] {
+    def encode(a: A): String
+  }
+
+  object ProtoEncoder {
+
+    implicit def defaultProtoMessageFieldEncoder(
+        implicit PME: ProtoEncoder[ProtoFieldMod]): ProtoEncoder[ProtoMessageField] =
+      new ProtoEncoder[ProtoMessageField] {
+        override def encode(a: ProtoMessageField): String = a match {
+          case m: ProtoEnum =>
+            s"""enum ${m.id} {
+               |  ${m.values.zipWithIndex.map { case (v, i) => s"${v.name} = $i" }.mkString(";\n")}
+               |}
+               |${a.mod.fold("")(m => PME.encode(m) + " ")}${a.id} ${a.name} = ${a.tag};
+         """.stripMargin
+          case _ => s"${a.mod.fold("")(m => PME.encode(m) + " ")}${a.id} ${a.name} = ${a.tag};"
+        }
+      }
+
+    implicit def defaultProtoMessageEncoder(
+        implicit MFEncoder: ProtoEncoder[ProtoMessageField]): ProtoEncoder[ProtoMessage] =
+      new ProtoEncoder[ProtoMessage] {
+        override def encode(a: ProtoMessage): String =
+          s"""message ${a.name} {
+             |${a.fields.map(MFEncoder.encode).mkString("  ", "\n  ", "")}
+             |}
+           """.stripMargin
+      }
+
+    implicit def defaultProtoMessageFieldModEncoder: ProtoEncoder[ProtoFieldMod] =
+      new ProtoEncoder[ProtoFieldMod] {
+        override def encode(a: ProtoFieldMod): String = a match {
+          case Repeated => "repeated"
+        }
+      }
+
+    implicit def defaultProtoServiceEncoder(
+        implicit MFEncoder: ProtoEncoder[ProtoServiceField]): ProtoEncoder[ProtoService] =
+      new ProtoEncoder[ProtoService] {
+        override def encode(a: ProtoService): String =
+          s"""service ${a.name} {
+             |${a.rpcs.map(MFEncoder.encode).mkString("  ", "\n  ", "")}
+             |}
+           """.stripMargin
+      }
+
+    implicit def defaultProtoServiceFieldEncoder: ProtoEncoder[ProtoServiceField] =
+      new ProtoEncoder[ProtoServiceField] {
+        override def encode(a: ProtoServiceField): String = a.streamingType match {
+          case None =>
+            s"rpc ${a.name} (${a.request.capitalize}) returns (${a.response.capitalize}) {}"
+          case Some(RequestStreaming) =>
+            s"rpc ${a.name} (stream ${a.request.capitalize}) returns (${a.response.capitalize}) {}"
+          case Some(ResponseStreaming) =>
+            s"rpc ${a.name} (${a.request.capitalize}) returns (stream ${a.response.capitalize}) {}"
+          case Some(BidirectionalStreaming) =>
+            s"rpc ${a.name} (stream ${a.request.capitalize}) returns (stream ${a.response.capitalize}) {}"
+        }
+
+      }
+
+    implicit def defaultProtoOptionEncoder: ProtoEncoder[ProtoOption] =
+      new ProtoEncoder[ProtoOption] {
+        override def encode(a: ProtoOption): String =
+          s"option ${a.name} = ${if (a.quote) { "\"" + a.value + "\"" } else a.value};"
+      }
+
+    implicit def defaultProtoDefinitionsEncoder(
+        implicit POM: ProtoEncoder[ProtoOption],
+        PEM: ProtoEncoder[ProtoMessage],
+        PES: ProtoEncoder[ProtoService]): ProtoEncoder[ProtoDefinitions] =
+      new ProtoEncoder[ProtoDefinitions] {
+        override def encode(d: ProtoDefinitions): String =
+          s"""${d.prelude}
+             |
+             |${d.options.map(POM.encode).mkString("\n").trim}
+             |
+             |${d.messages.map(PEM.encode).mkString("\n").trim}
+             |
+             |${d.services.map(PES.encode).mkString("\n").trim}
+           """.stripMargin
+
+      }
+
+  }
+
+}

--- a/modules/idlgen/core/src/main/scala/model.scala
+++ b/modules/idlgen/core/src/main/scala/model.scala
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc.idlgen.protobuf
+
+import freestyle.rpc.protocol._
+
+object model {
+
+  sealed trait ProtoFieldMod extends Product with Serializable
+
+  case object Repeated extends ProtoFieldMod
+
+  sealed trait ProtoMessageField extends Product with Serializable {
+    def mod: Option[ProtoFieldMod]
+
+    def name: String
+
+    def id: String
+
+    def tag: Int
+
+    def comment: Option[String]
+  }
+
+  final case class ProtoDouble(
+      mod: Option[ProtoFieldMod] = None,
+      name: String,
+      id: String = "double",
+      tag: Int,
+      comment: Option[String] = None)
+      extends ProtoMessageField
+
+  final case class ProtoFloat(
+      mod: Option[ProtoFieldMod] = None,
+      name: String,
+      id: String = "float",
+      tag: Int,
+      comment: Option[String] = None)
+      extends ProtoMessageField
+
+  final case class ProtoInt32(
+      mod: Option[ProtoFieldMod] = None,
+      name: String,
+      id: String = "int32",
+      tag: Int,
+      comment: Option[String] = None)
+      extends ProtoMessageField
+
+  final case class ProtoInt64(
+      mod: Option[ProtoFieldMod] = None,
+      name: String,
+      id: String = "int64",
+      tag: Int,
+      comment: Option[String] = None)
+      extends ProtoMessageField
+
+  final case class ProtoUInt32(
+      mod: Option[ProtoFieldMod] = None,
+      name: String,
+      id: String = "uint32",
+      tag: Int,
+      comment: Option[String] = None)
+      extends ProtoMessageField
+
+  final case class ProtoUInt64(
+      mod: Option[ProtoFieldMod] = None,
+      name: String,
+      id: String = "uint64",
+      tag: Int,
+      comment: Option[String] = None)
+      extends ProtoMessageField
+
+  final case class ProtoSInt32(
+      mod: Option[ProtoFieldMod] = None,
+      name: String,
+      id: String = "sint32",
+      tag: Int,
+      comment: Option[String] = None)
+      extends ProtoMessageField
+
+  final case class ProtoSInt64(
+      mod: Option[ProtoFieldMod] = None,
+      name: String,
+      id: String = "sint64",
+      tag: Int,
+      comment: Option[String] = None)
+      extends ProtoMessageField
+
+  final case class ProtoFInt32(
+      mod: Option[ProtoFieldMod] = None,
+      name: String,
+      id: String = "fixed32",
+      tag: Int,
+      comment: Option[String] = None)
+      extends ProtoMessageField
+
+  final case class ProtoFInt64(
+      mod: Option[ProtoFieldMod] = None,
+      name: String,
+      id: String = "fixed64",
+      tag: Int,
+      comment: Option[String] = None)
+      extends ProtoMessageField
+
+  final case class ProtoSFInt32(
+      mod: Option[ProtoFieldMod] = None,
+      name: String,
+      id: String = "sfixed32",
+      tag: Int,
+      comment: Option[String] = None)
+      extends ProtoMessageField
+
+  final case class ProtoSFInt64(
+      mod: Option[ProtoFieldMod] = None,
+      name: String,
+      id: String = "sfixed64",
+      tag: Int,
+      comment: Option[String] = None)
+      extends ProtoMessageField
+
+  final case class ProtoBool(
+      mod: Option[ProtoFieldMod] = None,
+      name: String,
+      id: String = "bool",
+      tag: Int,
+      comment: Option[String] = None)
+      extends ProtoMessageField
+
+  final case class ProtoString(
+      mod: Option[ProtoFieldMod] = None,
+      name: String,
+      id: String = "string",
+      tag: Int,
+      comment: Option[String] = None)
+      extends ProtoMessageField
+
+  final case class ProtoBytes(
+      mod: Option[ProtoFieldMod] = None,
+      name: String,
+      id: String = "bytes",
+      tag: Int,
+      comment: Option[String] = None)
+      extends ProtoMessageField
+
+  final case class ProtoEnum(
+      mod: Option[ProtoFieldMod] = None,
+      name: String,
+      id: String = "enum",
+      tag: Int,
+      values: List[ProtoEnumValue],
+      comment: Option[String] = None)
+      extends ProtoMessageField
+
+  final case class ProtoEnumValue(mod: Option[ProtoFieldMod] = None, name: String, tag: Int)
+
+  final case class ProtoCustomType(
+      mod: Option[ProtoFieldMod] = None,
+      name: String,
+      id: String,
+      tag: Int,
+      comment: Option[String] = None)
+      extends ProtoMessageField
+
+  final case class ProtoMessage(
+      mod: Option[ProtoFieldMod] = None,
+      name: String,
+      reservedNames: List[String] = Nil,
+      reservedTags: List[Int] = Nil,
+      fields: List[ProtoMessageField] = Nil)
+
+  final case class ProtoService(name: String, rpcs: List[ProtoServiceField])
+
+  final case class ProtoServiceField(
+      name: String,
+      request: String,
+      response: String,
+      streamingType: Option[StreamingType])
+
+  final case class ProtoOption(name: String, value: String, quote: Boolean)
+
+  final case class ProtoDefinitions(
+      prelude: String = """|// This file has been automatically generated for use by
+                           |// the protoGen plugin, from frees-rpc service definitions.
+                           |// Read more at: http://frees.io/docs/rpc/
+                           |
+                           |syntax = "proto3";""".stripMargin,
+      options: List[ProtoOption],
+      messages: List[ProtoMessage],
+      services: List[ProtoService])
+
+}

--- a/modules/idlgen/core/src/main/scala/processors.scala
+++ b/modules/idlgen/core/src/main/scala/processors.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc.idlgen.protobuf
+
+import cats._
+import cats.implicits._
+import freestyle.rpc.idlgen.protobuf.converters._
+import freestyle.rpc.idlgen.protobuf.model._
+import java.io.File
+import scala.meta._
+import simulacrum.typeclass
+
+object processors {
+
+  @typeclass
+  trait ProtoAnnotationsProcessor[M[_]] {
+    def process(file: File): M[ProtoDefinitions]
+  }
+
+  object ProtoAnnotationsProcessor {
+    implicit def defaultProtoAnnotationsProcessor[M[_]](
+        implicit ME: MonadError[M, Throwable],
+        C: ScalaMetaSource2ProtoDefinitions): ProtoAnnotationsProcessor[M] =
+      new DefaultProtoAnnotationsProcessor[M]()
+  }
+
+  class DefaultProtoAnnotationsProcessor[M[_]](
+      implicit ME: MonadError[M, Throwable],
+      C: ScalaMetaSource2ProtoDefinitions
+  ) extends ProtoAnnotationsProcessor[M] {
+
+    def process(file: File): M[ProtoDefinitions] = sourceOf(file) map C.convert
+
+    private[this] def sourceOf(file: File): M[Source] =
+      ME.catchNonFatal(file.parse[Source].get)
+
+  }
+
+}

--- a/modules/idlgen/core/src/test/proto/.gitignore
+++ b/modules/idlgen/core/src/test/proto/.gitignore
@@ -1,0 +1,3 @@
+*
+!/.gitignore
+!/*_Expected.proto

--- a/modules/idlgen/core/src/test/proto/GreeterService_Expected.proto
+++ b/modules/idlgen/core/src/test/proto/GreeterService_Expected.proto
@@ -1,0 +1,24 @@
+// This file has been automatically generated for use by
+// the protoGen plugin, from frees-rpc service definitions.
+// Read more at: http://frees.io/docs/rpc/
+
+syntax = "proto3";
+
+option java_package = "quickstart";
+option java_multiple_files = true;
+option java_outer_classname = "Quickstart";
+
+message HelloRequest {
+    string greeting = 1;
+}
+
+message HelloResponse {
+    string reply = 1;
+}
+
+service Greeter {
+    rpc sayHello (HelloRequest) returns (HelloResponse) {}
+    rpc lotsOfReplies (HelloRequest) returns (stream HelloResponse) {}
+    rpc lotsOfGreetings (stream HelloRequest) returns (HelloResponse) {}
+    rpc bidiHello (stream HelloRequest) returns (stream HelloResponse) {}
+}

--- a/modules/idlgen/core/src/test/scala/GreeterService.scala
+++ b/modules/idlgen/core/src/test/scala/GreeterService.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc.idlgen.protobuf
+
+import freestyle.rpc.protocol._
+
+@option(name = "java_package", value = "quickstart", quote = true)
+@option(name = "java_multiple_files", value = "true", quote = false)
+@option(name = "java_outer_classname", value = "Quickstart", quote = true)
+object GreeterService {
+
+  import monix.reactive.Observable
+
+  @message
+  case class HelloRequest(greeting: String)
+
+  @message
+  case class HelloResponse(reply: String)
+
+  @service
+  trait Greeter[F[_]] {
+
+    /**
+     * Unary RPC where the client sends a single request to the server and gets a single response back,
+     * just like a normal function call.
+     *
+     * https://grpc.io/docs/guides/concepts.html
+     *
+     * @param request Single client request.
+     * @return Single server response.
+     */
+    @rpc(Protobuf)
+    def sayHello(request: HelloRequest): F[HelloResponse]
+
+    /**
+     * Server streaming RPC where the client sends a request to the server and gets a stream to read a
+     * sequence of messages back. The client reads from the returned stream until there are no more messages.
+     *
+     * https://grpc.io/docs/guides/concepts.html
+     *
+     * @param request Single client request.
+     * @return Stream of server responses.
+     */
+    @rpc(Protobuf)
+    @stream[ResponseStreaming.type]
+    def lotsOfReplies(request: HelloRequest): Observable[HelloResponse]
+
+    /**
+     * Client streaming RPC where the client writes a sequence of messages and sends them to the server,
+     * again using a provided stream. Once the client has finished writing the messages, it waits for
+     * the server to read them and return its response.
+     *
+     * https://grpc.io/docs/guides/concepts.html
+     *
+     * @param request Stream of client requests.
+     * @return Single server response.
+     */
+    @rpc(Protobuf)
+    @stream[RequestStreaming.type]
+    def lotsOfGreetings(request: Observable[HelloRequest]): F[HelloResponse]
+
+    /**
+     * Bidirectional streaming RPC where both sides send a sequence of messages using a read-write stream.
+     * The two streams operate independently, so clients and servers can read and write in whatever order
+     * they like: for example, the server could wait to receive all the client messages before writing its
+     * responses, or it could alternately read a message then write a message, or some other combination of
+     * reads and writes. The order of messages in each stream is preserved.
+     *
+     * https://grpc.io/docs/guides/concepts.html
+     *
+     * @param request Stream of client requests.
+     * @return Stream of server responses.
+     */
+    @rpc(Protobuf)
+    @stream[BidirectionalStreaming.type]
+    def bidiHello(request: Observable[HelloRequest]): Observable[HelloResponse]
+
+  }
+
+}

--- a/modules/idlgen/core/src/test/scala/ProtoCodeGenTests.scala
+++ b/modules/idlgen/core/src/test/scala/ProtoCodeGenTests.scala
@@ -24,7 +24,9 @@ class ProtoCodeGenTests extends RpcBaseTestSuite {
 
   s"$ProtoCodeGen.generate()" should {
     "generate a correct .proto file" in {
-      val baseDir       = "src/test"
+      // Clunky workaround for Travis CI env until we refactor Protogen to use classpath-provided streams
+      val baseDir = Option(System.getenv("TRAVIS_BUILD_DIR")).fold(".")(travisDir =>
+        s"$travisDir/frees-io/freestyle-rpc/modules/idlgen/core") + "/src/test"
       val srcDir        = s"$baseDir/scala"
       val dstDir        = s"$baseDir/proto"
       val output        = ProtoCodeGen.generate(new File(srcDir), new File(dstDir)).flatten

--- a/modules/idlgen/core/src/test/scala/ProtoCodeGenTests.scala
+++ b/modules/idlgen/core/src/test/scala/ProtoCodeGenTests.scala
@@ -26,7 +26,7 @@ class ProtoCodeGenTests extends RpcBaseTestSuite {
     "generate a correct .proto file" in {
       // Clunky workaround for Travis CI env until we refactor Protogen to use classpath-provided streams
       val baseDir = Option(System.getenv("TRAVIS_BUILD_DIR")).fold(".")(travisDir =>
-        s"$travisDir/frees-io/freestyle-rpc/modules/idlgen/core") + "/src/test"
+        s"$travisDir/modules/idlgen/core") + "/src/test"
       val srcDir        = s"$baseDir/scala"
       val dstDir        = s"$baseDir/proto"
       val output        = ProtoCodeGen.generate(new File(srcDir), new File(dstDir)).flatten

--- a/modules/idlgen/core/src/test/scala/ProtoCodeGenTests.scala
+++ b/modules/idlgen/core/src/test/scala/ProtoCodeGenTests.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc.idlgen.protobuf
+
+import freestyle.rpc.common.RpcBaseTestSuite
+import java.io.File
+import scala.io.Source
+
+class ProtoCodeGenTests extends RpcBaseTestSuite {
+
+  s"$ProtoCodeGen.generate()" should {
+    "generate a correct .proto file" in {
+      val baseDir       = "src/test"
+      val srcDir        = s"$baseDir/scala"
+      val dstDir        = s"$baseDir/proto"
+      val output        = ProtoCodeGen.generate(new File(srcDir), new File(dstDir)).flatten
+      val greeterOutput = output.find(_._1 == new File(s"$dstDir/GreeterService.proto"))
+      greeterOutput should not be empty
+      val outputLines = greeterOutput.get._2.split("\n")
+      val expectedLines =
+        Source.fromFile(s"$dstDir/GreeterService_Expected.proto", "UTF-8").getLines.toArray
+      // initial line breaks make it easier to compare the arrays in ScalaTest assertion errors
+      "\n" +: trimmed(outputLines) shouldBe "\n" +: trimmed(expectedLines)
+    }
+  }
+
+  private def trimmed(output: Array[String]) = output.map(_.trim).filter(_.nonEmpty)
+
+}

--- a/modules/idlgen/plugin/src/main/scala/ProtoGenPlugin.scala
+++ b/modules/idlgen/plugin/src/main/scala/ProtoGenPlugin.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc.idlgen.protobuf
+
+import sbt._
+import sbt.Keys._
+
+object ProtoGenPlugin extends AutoPlugin {
+
+  override def trigger: PluginTrigger = allRequirements
+
+  object autoImport {
+
+    lazy val protoGen: TaskKey[Unit] =
+      taskKey[Unit]("Generates .proto files from freestyle-rpc service definitions")
+
+    lazy val protoGenSourceDir: SettingKey[File] =
+      settingKey[File](
+        "The Scala source directory, where your freestyle-rpc service definitions are placed.")
+
+    lazy val protoGenTargetDir: SettingKey[File] =
+      settingKey[File](
+        "The Protocol Buffers target directory, where the `protoGen` task will " +
+          "write the `.proto` files, based on freestyle-rpc service definitions.")
+  }
+
+  import autoImport._
+
+  lazy val defaultSettings: Seq[Def.Setting[_]] = Seq(
+    protoGenSourceDir := baseDirectory.value / "src" / "main" / "scala",
+    protoGenTargetDir := baseDirectory.value / "src" / "main" / "proto"
+  )
+
+  lazy val protoGenTaskSettings: Seq[Def.Setting[_]] = Seq(
+    protoGen := {
+      (runner in Compile).value
+        .run(
+          mainClass = "freestyle.rpc.idlgen.protobuf.ProtoCodeGen",
+          classpath = sbt.Attributed.data((fullClasspath in Compile).value),
+          options = Seq(
+            protoGenSourceDir.value.absolutePath,
+            protoGenTargetDir.value.absolutePath
+          ),
+          log = streams.value.log
+        )
+      (): Unit
+    }
+  )
+
+  override def projectSettings: Seq[Def.Setting[_]] =
+    defaultSettings ++ protoGenTaskSettings ++ Seq(
+      libraryDependencies += "io.frees" %% "frees-rpc-idlgen-core" % freestyle.rpc.idlgen.BuildInfo.version
+    )
+}

--- a/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/basic/.gitignore
+++ b/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/basic/.gitignore
@@ -1,0 +1,1 @@
+src/main/proto/model.proto

--- a/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/basic/build.sbt
+++ b/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/basic/build.sbt
@@ -1,7 +1,7 @@
-version := "1.0"
+version := sys.props("version")
 
 resolvers += Resolver.bintrayRepo("beyondthelines", "maven")
 
 libraryDependencies ++= Seq(
-  "io.frees" %% "frees-rpc-server" % "0.11.1"
+  "io.frees" %% "frees-rpc-server" % sys.props("version")
 )

--- a/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/basic/build.sbt
+++ b/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/basic/build.sbt
@@ -1,0 +1,7 @@
+version := "1.0"
+
+resolvers += Resolver.bintrayRepo("beyondthelines", "maven")
+
+libraryDependencies ++= Seq(
+  "io.frees" %% "frees-rpc-server" % "0.11.1"
+)

--- a/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/basic/project/plugins.sbt
+++ b/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/basic/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("io.frees" %% "sbt-frees-rpc-idlgen" % sys.props("plugin.version"))
+addSbtPlugin("io.frees" %% "sbt-frees-rpc-idlgen" % sys.props("version"))

--- a/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/basic/project/plugins.sbt
+++ b/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/basic/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("io.frees" %% "sbt-frees-rpc-idlgen" % sys.props("plugin.version"))

--- a/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/basic/src/main/scala/model.scala
+++ b/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/basic/src/main/scala/model.scala
@@ -1,0 +1,4 @@
+import freestyle.rpc.protocol._
+
+@message
+case class Person(id: Long, name: String, email: Option[String])

--- a/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/basic/test
+++ b/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/basic/test
@@ -1,0 +1,5 @@
+> protoGen
+
+$ exists src/main/proto/model.proto
+
+$ delete src/main/proto/model.proto

--- a/modules/internal/src/main/scala/service.scala
+++ b/modules/internal/src/main/scala/service.scala
@@ -90,7 +90,8 @@ trait RPCService {
 
   val innerImports: List[Stat] = imports
 
-  private[this] val (noRequests, requests) = buildRequests(algName, typeParam, noImports)
+  val (noRequests, requests): (List[Stat], List[RPCRequest]) =
+    buildRequests(algName, typeParam, noImports)
 
   val methodDescriptors: Seq[Defn.Val] = requests.map(_.methodDescriptor)
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -131,6 +131,12 @@ object ProjectPlugin extends AutoPlugin {
       )
     )
 
+    lazy val sbtPluginSettings: Seq[Def.Setting[_]] = Seq(
+      libraryDependencies ++= Seq(
+        "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
+      )
+    )
+
     lazy val docsSettings = Seq(
       // Pointing to https://github.com/frees-io/freestyle/tree/master/docs/src/main/tut/docs/rpc
       tutTargetDirectory := baseDirectory.value.getParentFile.getParentFile / "docs" / "src" / "main" / "tut" / "docs" / "rpc"

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -3,9 +3,16 @@ import freestyle.FreestylePlugin
 import freestyle.FreestylePlugin.autoImport._
 import sbt.Keys._
 import sbt._
+import sbt.ScriptedPlugin.autoImport._
 import sbtorgpolicies.OrgPoliciesPlugin.autoImport._
 import sbtorgpolicies.templates.badges._
 import sbtorgpolicies.runnable.syntax._
+import sbtrelease.ReleasePlugin.autoImport.{
+  releaseProcess,
+  releaseStepCommandAndRemaining,
+  ReleaseStep
+}
+import sbtrelease.ReleaseStateTransformations._
 import tut.TutPlugin.autoImport._
 
 object ProjectPlugin extends AutoPlugin {
@@ -132,8 +139,20 @@ object ProjectPlugin extends AutoPlugin {
     )
 
     lazy val sbtPluginSettings: Seq[Def.Setting[_]] = Seq(
-      libraryDependencies ++= Seq(
-        "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
+      scriptedLaunchOpts := {
+        scriptedLaunchOpts.value ++
+          Seq(
+            "-Xmx2048M",
+            "-XX:ReservedCodeCacheSize=256m",
+            "-XX:+UseConcMarkSweepGC",
+            "-Dplugin.version=" + version.value,
+            "-Dscala.version=" + scalaVersion.value
+          )
+      },
+      // Custom release process for the plugin:
+      releaseProcess := Seq[ReleaseStep](
+        releaseStepCommandAndRemaining("^ publishSigned"),
+        ReleaseStep(action = "sonatypeReleaseAll" :: _)
       )
     )
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -7,12 +7,8 @@ import sbt.ScriptedPlugin.autoImport._
 import sbtorgpolicies.OrgPoliciesPlugin.autoImport._
 import sbtorgpolicies.templates.badges._
 import sbtorgpolicies.runnable.syntax._
-import sbtrelease.ReleasePlugin.autoImport.{
-  releaseProcess,
-  releaseStepCommandAndRemaining,
-  ReleaseStep
-}
-import sbtrelease.ReleaseStateTransformations._
+import sbtrelease.ReleasePlugin.autoImport._
+import scala.language.reflectiveCalls
 import tut.TutPlugin.autoImport._
 
 object ProjectPlugin extends AutoPlugin {
@@ -145,8 +141,7 @@ object ProjectPlugin extends AutoPlugin {
             "-Xmx2048M",
             "-XX:ReservedCodeCacheSize=256m",
             "-XX:+UseConcMarkSweepGC",
-            "-Dplugin.version=" + version.value,
-            "-Dscala.version=" + scalaVersion.value
+            "-Dversion=" + version.value
           )
       },
       // Custom release process for the plugin:

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
 resolvers += Resolver.sonatypeRepo("releases")
 addSbtPlugin("io.frees" % "sbt-freestyle" % "0.3.19")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
 resolvers += Resolver.sonatypeRepo("releases")
-addSbtPlugin("io.frees" % "sbt-freestyle" % "0.3.19")
+addSbtPlugin("io.frees"     % "sbt-freestyle" % "0.3.19")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
+
+libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value


### PR DESCRIPTION
Resolves #180 and fixes https://github.com/frees-io/sbt-freestyle-protogen/issues/24. Note that this initial merge is mostly a straight-up copy of the current `sbt-freestyle-protogen` with different modules and package names, that removes the duplicated macro-processing code for `@rpc`-annotated methods and adds a basic unit test. There's still work to do on refactorings to be prepare for Avro gen, adding test coverage, and fixing some non-standard-compliant `.proto` output. (For the latter case I updated the readme to reflect what `protoGen` actually generates currently). Those remaining issues will be fixed in upcoming patches.