### PR TITLE
Fixes Sbt Issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,16 +32,24 @@ before_install:
 
 script:
 - sbt ++$TRAVIS_SCALA_VERSION orgScriptCI
-- sbt ++$TRAVIS_SCALA_VERSION scripted
 
-after_success:
-- bash <(curl -s https://codecov.io/bash) -t 5b75b318-ab71-4fbc-9203-bfa7765cdbdc
+stages:
+- test
+- plugin
+- deploy
 
 jobs:
   include:
+    - stage: plugin
+      scala: 2.12.4
+      script:
+        - sbt ++$TRAVIS_SCALA_VERSION idlgen-core/test
+        - sbt ++$TRAVIS_SCALA_VERSION idlgen-sbt/test
+        - sbt ++$TRAVIS_SCALA_VERSION idlgen-sbt/scripted
     - stage: deploy
       scala: 2.12.4
       script:
+        - bash <(curl -s https://codecov.io/bash) -t 5b75b318-ab71-4fbc-9203-bfa7765cdbdc
         - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then
             if grep -q "SNAPSHOT" version.sbt; then
               sbt ++$TRAVIS_SCALA_VERSION publish;

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ jobs:
       script:
         - sbt ++$TRAVIS_SCALA_VERSION idlgen-core/test
         - sbt ++$TRAVIS_SCALA_VERSION idlgen-sbt/test
-        - sbt ++$TRAVIS_SCALA_VERSION idlgen-sbt/scripted
+        - sbt ++$TRAVIS_SCALA_VERSION idlgen-core/publishLocal idlgen-sbt/publishLocal idlgen-sbt/scripted
     - stage: deploy
       scala: 2.12.4
       script:
@@ -60,6 +60,7 @@ jobs:
               git checkout master;
               git pull origin master;
               sbt release;
+              sbt idlgen-sbt/release;
               sbt depUpdateDependencyIssues;
             fi
           fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ jobs:
       script:
         - sbt ++$TRAVIS_SCALA_VERSION idlgen-core/test
         - sbt ++$TRAVIS_SCALA_VERSION idlgen-sbt/test
-        - sbt ++$TRAVIS_SCALA_VERSION idlgen-core/publishLocal idlgen-sbt/publishLocal idlgen-sbt/scripted
+        - sbt ++$TRAVIS_SCALA_VERSION publishLocal idlgen-sbt/publishLocal idlgen-sbt/scripted
     - stage: deploy
       scala: 2.12.4
       script:

--- a/build.sbt
+++ b/build.sbt
@@ -116,7 +116,7 @@ lazy val `idlgen-sbt` = project
   .in(file("modules/idlgen/plugin"))
   .aggregate(`idlgen-core`)
   .dependsOn(`idlgen-core` % "compile->compile;test->test")
-  .settings(moduleName := "frees-rpc-sbt-idlgen")
+  .settings(moduleName := "sbt-frees-rpc-idlgen")
   .settings(sbtPluginSettings)
   .settings(sbtPlugin := true)
   .settings(crossScalaVersions := Seq(scalac.`2.12`)) // org.scala-sbt:scripted-plugin not available in 2.11 for recent sbt

--- a/build.sbt
+++ b/build.sbt
@@ -158,7 +158,8 @@ lazy val allModules: Seq[ProjectReference] = Seq(
   `dropwizard-server`,
   `dropwizard-client`,
   testing,
-  ssl
+  ssl,
+  `idlgen-core`
 )
 
 lazy val allModulesDeps: Seq[ClasspathDependency] =

--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ lazy val common = project
   .in(file("modules/common"))
   .settings(moduleName := "frees-rpc-common")
   .settings(commonSettings)
+  .disablePlugins(ScriptedPlugin)
 
 lazy val internal = project
   .in(file("modules/internal"))
@@ -15,6 +16,7 @@ lazy val internal = project
   .dependsOn(testing % "test->test")
   .settings(moduleName := "frees-rpc-internal")
   .settings(internalSettings)
+  .disablePlugins(ScriptedPlugin)
 
 lazy val client = project
   .in(file("modules/client"))
@@ -23,18 +25,21 @@ lazy val client = project
   .dependsOn(testing % "test->test")
   .settings(moduleName := "frees-rpc-client-core")
   .settings(clientCoreSettings)
+  .disablePlugins(ScriptedPlugin)
 
 lazy val `client-netty` = project
   .in(file("modules/client-netty"))
   .dependsOn(client % "compile->compile;test->test")
   .settings(moduleName := "frees-rpc-client-netty")
   .settings(clientNettySettings)
+  .disablePlugins(ScriptedPlugin)
 
 lazy val `client-okhttp` = project
   .in(file("modules/client-okhttp"))
   .dependsOn(client % "compile->compile;test->test")
   .settings(moduleName := "frees-rpc-client-okhttp")
   .settings(clientOkHttpSettings)
+  .disablePlugins(ScriptedPlugin)
 
 lazy val server = project
   .in(file("modules/server"))
@@ -44,6 +49,7 @@ lazy val server = project
   .dependsOn(testing % "test->test")
   .settings(moduleName := "frees-rpc-server")
   .settings(serverSettings)
+  .disablePlugins(ScriptedPlugin)
 
 lazy val config = project
   .in(file("modules/config"))
@@ -53,23 +59,27 @@ lazy val config = project
   .dependsOn(testing % "test->test")
   .settings(moduleName := "frees-rpc-config")
   .settings(configSettings)
+  .disablePlugins(ScriptedPlugin)
 
 lazy val interceptors = project
   .in(file("modules/interceptors"))
   .settings(moduleName := "frees-rpc-interceptors")
   .settings(interceptorsSettings)
+  .disablePlugins(ScriptedPlugin)
 
 lazy val `prometheus-shared` = project
   .in(file("modules/prometheus/shared"))
   .dependsOn(interceptors % "compile->compile;test->test")
   .settings(moduleName := "frees-rpc-prometheus-shared")
   .settings(prometheusSettings)
+  .disablePlugins(ScriptedPlugin)
 
 lazy val `prometheus-server` = project
   .in(file("modules/prometheus/server"))
   .dependsOn(`prometheus-shared` % "compile->compile;test->test")
   .dependsOn(server % "compile->compile;test->test")
   .settings(moduleName := "frees-rpc-prometheus-server")
+  .disablePlugins(ScriptedPlugin)
 
 lazy val `prometheus-client` = project
   .in(file("modules/prometheus/client"))
@@ -78,6 +88,7 @@ lazy val `prometheus-client` = project
   .dependsOn(server % "test->test")
   .settings(moduleName := "frees-rpc-prometheus-client")
   .settings(prometheusClientSettings)
+  .disablePlugins(ScriptedPlugin)
 
 lazy val `dropwizard-server` = project
   .in(file("modules/dropwizard/server"))
@@ -85,6 +96,7 @@ lazy val `dropwizard-server` = project
   .dependsOn(server % "compile->compile;test->test")
   .settings(moduleName := "frees-rpc-dropwizard-server")
   .settings(dropwizardSettings)
+  .disablePlugins(ScriptedPlugin)
 
 lazy val `dropwizard-client` = project
   .in(file("modules/dropwizard/client"))
@@ -93,11 +105,13 @@ lazy val `dropwizard-client` = project
   .dependsOn(server % "test->test")
   .settings(moduleName := "frees-rpc-dropwizard-client")
   .settings(dropwizardSettings)
+  .disablePlugins(ScriptedPlugin)
 
 lazy val testing = project
   .in(file("modules/testing"))
   .settings(moduleName := "frees-rpc-testing")
   .settings(testingSettings)
+  .disablePlugins(ScriptedPlugin)
 
 lazy val ssl = project
   .in(file("modules/ssl"))
@@ -105,21 +119,22 @@ lazy val ssl = project
   .dependsOn(`client-netty` % "compile->compile;test->test")
   .settings(moduleName := "frees-rpc-netty-ssl")
   .settings(nettySslSettings)
+  .disablePlugins(ScriptedPlugin)
 
 lazy val `idlgen-core` = project
   .in(file("modules/idlgen/core"))
   .dependsOn(internal)
   .dependsOn(client % "test->test")
   .settings(moduleName := "frees-rpc-idlgen-core")
+  .disablePlugins(ScriptedPlugin)
 
 lazy val `idlgen-sbt` = project
   .in(file("modules/idlgen/plugin"))
-  .aggregate(`idlgen-core`)
-  .dependsOn(`idlgen-core` % "compile->compile;test->test")
+  .dependsOn(`idlgen-core`)
   .settings(moduleName := "sbt-frees-rpc-idlgen")
-  .settings(sbtPluginSettings)
   .settings(sbtPlugin := true)
-  .settings(crossScalaVersions := Seq(scalac.`2.12`)) // org.scala-sbt:scripted-plugin not available in 2.11 for recent sbt
+  .settings(crossScalaVersions := Seq(scalac.`2.12`))
+  .settings(sbtPluginSettings: _*)
   .enablePlugins(BuildInfoPlugin)
   .settings(buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion))
   .settings(buildInfoPackage := "freestyle.rpc.idlgen")
@@ -155,6 +170,7 @@ lazy val root = project
   .settings(noPublishSettings)
   .aggregate(allModules: _*)
   .dependsOn(allModulesDeps: _*)
+  .disablePlugins(ScriptedPlugin)
 
 lazy val docs = project
   .in(file("docs"))

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import sbtorgpolicies.model.scalac
+
 pgpPassphrase := Some(getEnvVar("PGP_PASSPHRASE").getOrElse("").toCharArray)
 pgpPublicRing := file(s"$gpgFolder/pubring.gpg")
 pgpSecretRing := file(s"$gpgFolder/secring.gpg")
@@ -117,7 +119,7 @@ lazy val `idlgen-sbt` = project
   .settings(moduleName := "frees-rpc-sbt-idlgen")
   .settings(sbtPluginSettings)
   .settings(sbtPlugin := true)
-  .settings(crossScalaVersions := Seq(scalaVersion.value)) // org.scala-sbt:scripted-plugin not available in 2.11 for recent sbt
+  .settings(crossScalaVersions := Seq(scalac.`2.12`)) // org.scala-sbt:scripted-plugin not available in 2.11 for recent sbt
   .enablePlugins(BuildInfoPlugin)
   .settings(buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion))
   .settings(buildInfoPackage := "freestyle.rpc.idlgen")
@@ -141,9 +143,7 @@ lazy val allModules: Seq[ProjectReference] = Seq(
   `dropwizard-server`,
   `dropwizard-client`,
   testing,
-  ssl,
-  `idlgen-core`,
-  `idlgen-sbt`
+  ssl
 )
 
 lazy val allModulesDeps: Seq[ClasspathDependency] =

--- a/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/basic/.gitignore
+++ b/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/basic/.gitignore
@@ -1,0 +1,1 @@
+src/main/proto/model.proto

--- a/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/basic/build.sbt
+++ b/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/basic/build.sbt
@@ -1,0 +1,7 @@
+version := "1.0"
+
+resolvers += Resolver.bintrayRepo("beyondthelines", "maven")
+
+libraryDependencies ++= Seq(
+  "io.frees" %% "frees-rpc-server" % "0.11.1"
+)

--- a/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/basic/project/plugins.sbt
+++ b/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/basic/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("io.frees" %% "sbt-frees-rpc-idlgen" % sys.props("plugin.version"))

--- a/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/basic/src/main/scala/model.scala
+++ b/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/basic/src/main/scala/model.scala
@@ -1,0 +1,4 @@
+import freestyle.rpc.protocol._
+
+@message
+case class Person(id: Long, name: String, email: Option[String])

--- a/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/basic/test
+++ b/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/basic/test
@@ -1,0 +1,5 @@
+> protoGen
+
+$ exists src/main/proto/model.proto
+
+$ delete src/main/proto/model.proto

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -7,6 +7,12 @@ import sbt.ScriptedPlugin.autoImport._
 import sbtorgpolicies.OrgPoliciesPlugin.autoImport._
 import sbtorgpolicies.templates.badges._
 import sbtorgpolicies.runnable.syntax._
+import sbtrelease.ReleasePlugin.autoImport.{
+  releaseProcess,
+  releaseStepCommandAndRemaining,
+  ReleaseStep
+}
+import sbtrelease.ReleaseStateTransformations._
 import tut.TutPlugin.autoImport._
 
 object ProjectPlugin extends AutoPlugin {
@@ -142,7 +148,12 @@ object ProjectPlugin extends AutoPlugin {
             "-Dplugin.version=" + version.value,
             "-Dscala.version=" + scalaVersion.value
           )
-      }
+      },
+      // Custom release process for the plugin:
+      releaseProcess := Seq[ReleaseStep](
+        releaseStepCommandAndRemaining("^ publishSigned"),
+        ReleaseStep(action = "sonatypeReleaseAll" :: _)
+      )
     )
 
     lazy val docsSettings = Seq(

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -3,6 +3,7 @@ import freestyle.FreestylePlugin
 import freestyle.FreestylePlugin.autoImport._
 import sbt.Keys._
 import sbt._
+import sbt.ScriptedPlugin.autoImport._
 import sbtorgpolicies.OrgPoliciesPlugin.autoImport._
 import sbtorgpolicies.templates.badges._
 import sbtorgpolicies.runnable.syntax._
@@ -132,9 +133,16 @@ object ProjectPlugin extends AutoPlugin {
     )
 
     lazy val sbtPluginSettings: Seq[Def.Setting[_]] = Seq(
-      libraryDependencies ++= Seq(
-        "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
-      )
+      scriptedLaunchOpts := {
+        scriptedLaunchOpts.value ++
+          Seq(
+            "-Xmx2048M",
+            "-XX:ReservedCodeCacheSize=256m",
+            "-XX:+UseConcMarkSweepGC",
+            "-Dplugin.version=" + version.value,
+            "-Dscala.version=" + scalaVersion.value
+          )
+      }
     )
 
     lazy val docsSettings = Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
 resolvers += Resolver.sonatypeRepo("releases")
-addSbtPlugin("io.frees" % "sbt-freestyle" % "0.3.19")
+addSbtPlugin("io.frees"     % "sbt-freestyle" % "0.3.19")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
+
+libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value


### PR DESCRIPTION
This PR brings several things in order to fix the current sbt plugin once we've moved to the core:

* In Travis, we are building the Sbt Plugin in a different stage, preventing issues with the Scala 2.11 version.
* Loads scripted plugin only for Scala 2.12.
* Removes the plugin stuff from the core build. It should be built independently.
* Migrates the existing scripted tests from https://github.com/frees-io/sbt-freestyle-protogen/tree/master/src/sbt-test/sbt-freestyle-protogen to the plugin module.
* Plugin name has been renamed from `frees-rpc-sbt-idlgen` to `sbt-frees-rpc-idlgen`, following the pattern `sbt-whatever`, this is just a suggestion, let me know if it makes sense to you.