### PR TITLE
Fixed stacktraces in tests caused by unclosed channels

### DIFF
--- a/modules/client-netty/src/test/scala/ManagedChannelInterpreterNettyTests.scala
+++ b/modules/client-netty/src/test/scala/ManagedChannelInterpreterNettyTests.scala
@@ -35,7 +35,7 @@ class ManagedChannelInterpreterNettyTests extends ManagedChannelInterpreterTests
 
   "NettyChannelInterpreter" should {
 
-    "build a io.grpc.ManagedChannel based on the specified configuration, for a Socket Address" in {
+    "build an io.grpc.ManagedChannel based on the specified configuration, for a Socket Address" in {
 
       val channelFor: ChannelFor = ChannelForSocketAddress(new InetSocketAddress(SC.host, 45455))
 
@@ -45,10 +45,12 @@ class ManagedChannelInterpreterNettyTests extends ManagedChannelInterpreterTests
 
       val mc: ManagedChannel = interpreter.build
 
-      mc shouldBe an[ManagedChannel]
+      mc shouldBe a[ManagedChannel]
+
+      mc.shutdownNow()
     }
 
-    "build a io.grpc.ManagedChannel based on the specified configuration, for Target" in {
+    "build an io.grpc.ManagedChannel based on the specified configuration, for a Target" in {
 
       val channelFor: ChannelFor = ChannelForTarget(SC.host)
 
@@ -56,10 +58,12 @@ class ManagedChannelInterpreterNettyTests extends ManagedChannelInterpreterTests
 
       val mc: ManagedChannel = interpreter.build
 
-      mc shouldBe an[ManagedChannel]
+      mc shouldBe a[ManagedChannel]
+
+      mc.shutdownNow()
     }
 
-    "build a io.grpc.ManagedChannel based on any configuration combination" in {
+    "build an io.grpc.ManagedChannel based on any configuration combination" in {
 
       val channelFor: ChannelFor = ChannelForAddress(SC.host, SC.port)
 
@@ -82,7 +86,9 @@ class ManagedChannelInterpreterNettyTests extends ManagedChannelInterpreterTests
 
       val mc: ManagedChannel = interpreter.build
 
-      mc shouldBe an[ManagedChannel]
+      mc shouldBe a[ManagedChannel]
+
+      mc.shutdownNow()
     }
 
     "throw an exception when configuration is not recognized" in {
@@ -94,7 +100,7 @@ class ManagedChannelInterpreterNettyTests extends ManagedChannelInterpreterTests
 
       val interpreter = new NettyChannelInterpreter(channelFor, channelConfigList)
 
-      an[MatchError] shouldBe thrownBy(interpreter.build)
+      a[MatchError] shouldBe thrownBy(interpreter.build)
     }
 
     "throw an exception when ChannelFor is not recognized" in {

--- a/modules/client/src/test/scala/ManagedChannelInterpreterTests.scala
+++ b/modules/client/src/test/scala/ManagedChannelInterpreterTests.scala
@@ -42,9 +42,11 @@ abstract class ManagedChannelInterpreterTests extends RpcClientTestSuite {
       val mc: ManagedChannel = managedChannelInterpreter.build(channelFor, channelConfigList)
 
       mc shouldBe an[ManagedChannel]
+
+      mc.shutdownNow()
     }
 
-    "build a io.grpc.ManagedChannel based on the specified configuration, for an target" in {
+    "build a io.grpc.ManagedChannel based on the specified configuration, for a target" in {
 
       val channelFor: ChannelFor = ChannelForTarget(SC.host)
 
@@ -55,7 +57,9 @@ abstract class ManagedChannelInterpreterTests extends RpcClientTestSuite {
 
       val mc: ManagedChannel = managedChannelInterpreter.build(channelFor, channelConfigList)
 
-      mc shouldBe an[ManagedChannel]
+      mc shouldBe a[ManagedChannel]
+
+      mc.shutdownNow()
     }
 
     "apply should work as expected" in {
@@ -68,7 +72,10 @@ abstract class ManagedChannelInterpreterTests extends RpcClientTestSuite {
         new ManagedChannelInterpreter[Future](channelFor, channelConfigList)
 
       val kleisli: ManagedChannelOps[Future, String] =
-        Kleisli[Future, ManagedChannel, String]((_: ManagedChannel) => Future.successful(foo))
+        Kleisli[Future, ManagedChannel, String]((mc: ManagedChannel) => {
+          mc.shutdownNow()
+          Future.successful(foo)
+        })
 
       Await.result(managedChannelInterpreter[String](kleisli), Duration.Inf) shouldBe foo
     }
@@ -84,7 +91,9 @@ abstract class ManagedChannelInterpreterTests extends RpcClientTestSuite {
 
       val mc: ManagedChannel = managedChannelInterpreter.build(channelFor, channelConfigList)
 
-      mc shouldBe an[ManagedChannel]
+      mc shouldBe a[ManagedChannel]
+
+      mc.shutdownNow()
     }
 
     "throw an exception when configuration is not recognized" in {
@@ -97,7 +106,7 @@ abstract class ManagedChannelInterpreterTests extends RpcClientTestSuite {
       val managedChannelInterpreter =
         new ManagedChannelInterpreter[Future](channelFor, channelConfigList)
 
-      an[MatchError] shouldBe thrownBy(
+      a[MatchError] shouldBe thrownBy(
         managedChannelInterpreter.build(channelFor, channelConfigList))
     }
 

--- a/modules/server/src/test/scala/CommonUtils.scala
+++ b/modules/server/src/test/scala/CommonUtils.scala
@@ -22,10 +22,13 @@ import cats.Functor
 import cats.syntax.functor._
 import freestyle.rpc.common._
 import freestyle.rpc.server._
+import org.slf4j.LoggerFactory
 
 import scala.util.{Failure, Success, Try}
 
 trait CommonUtils {
+
+  private lazy val logger = LoggerFactory.getLogger(getClass)
 
   object database {
 
@@ -65,8 +68,7 @@ trait CommonUtils {
   def serverStop[F[_]: Functor](implicit S: GrpcServer[F]): F[Unit] =
     S.shutdownNow().void
 
-  def debug(str: String): Unit =
-    println(s"\n\n$str\n\n")
+  def debug(str: String): Unit = logger.debug(str)
 
   implicit val S: monix.execution.Scheduler = monix.execution.Scheduler.Implicits.global
 


### PR DESCRIPTION
Also replaced `println` statement with logging, and fixed some grammar in tests.