### PR TITLE
Fixes in idlGen header, docs and tests

### DIFF
--- a/docs/src/main/tut/core-concepts.md
+++ b/docs/src/main/tut/core-concepts.md
@@ -181,7 +181,7 @@ We are also using some additional annotations:
 
 We'll see more details about these and other annotations in the following sections.
 
-## Compression
+### Compression
 
 [frees-rpc] allows us to compress the data we are sending in our services. We can enable this compression either on the server or the client side.
 
@@ -256,7 +256,7 @@ object implicits extends Implicits
 
 ```
 
-## Service Methods
+### Service Methods
 
 As [gRPC], [frees-rpc] allows you to define two main kinds of service methods:
 

--- a/docs/src/main/tut/core-concepts.md
+++ b/docs/src/main/tut/core-concepts.md
@@ -256,7 +256,7 @@ object implicits extends Implicits
 
 ```
 
-### Service Methods
+## Service Methods
 
 As [gRPC], [frees-rpc] allows you to define two main kinds of service methods:
 

--- a/docs/src/main/tut/idl-generation.md
+++ b/docs/src/main/tut/idl-generation.md
@@ -10,7 +10,7 @@ permalink: /docs/rpc/idl-generation
 
 Before entering implementation details, we mentioned that the [frees-rpc] ecosystem brings the ability to generate `.proto` files from the Scala definition, in order to maintain compatibility with other languages and systems outside of Scala.
 
-This responsibility relies on `idlGen`, an sbt plugin to generate Protobuf and Avro IDL files from the [frees-rpc] service definitions.
+This relies on `idlGen`, an sbt plugin to generate Protobuf and Avro IDL files from the [frees-rpc] service definitions.
 
 ### Plugin Installation
 
@@ -47,8 +47,8 @@ Let's take our previous service, and add an Avro-specific request and some usefu
 ```tut:silent
 import freestyle.rpc.protocol._
 
-@option(name = "java_multiple_files", value = true)
-@option(name = "java_outer_classname", value = "Quickstart")
+@option("java_multiple_files", true)
+@option("java_outer_classname", "Quickstart")
 @outputName("GreeterService")
 @outputPackage("quickstart")
 object service {
@@ -96,8 +96,8 @@ Using this example, the resulting Protobuf IDL would be generated in `/src/main/
 
 syntax = "proto3";
 
-option java_package = "quickstart";
 option java_multiple_files = true;
+option java_outer_class_name = "Quickstart";
 
 package quickstart;
 

--- a/modules/idlgen/core/src/main/scala/Application.scala
+++ b/modules/idlgen/core/src/main/scala/Application.scala
@@ -28,7 +28,7 @@ object Application {
   val Separator: String  = "-" * 80
 
   def main(args: Array[String]): Unit = {
-    require(args.length >= 2, s"Usage: ${getClass.getName} inputPath outputPath")
+    require(args.length >= 2, s"\nUsage: ${getClass.getName.replace("$", "")} inputPath outputPath")
     val inputPath  = new File(args(0)).requireExisting
     val outputPath = new File(args(1)).requireExisting
     inputPath.allMatching(_.getName.endsWith(ScalaFileExtension)).foreach { inputFile =>

--- a/modules/idlgen/core/src/main/scala/ProtoGenerator.scala
+++ b/modules/idlgen/core/src/main/scala/ProtoGenerator.scala
@@ -30,7 +30,7 @@ object ProtoGenerator extends Generator {
   private val HeaderLines = Seq(
     "// This file has been automatically generated for use by",
     "// the idlGen plugin, from frees-rpc service definitions.",
-    "// Read more at: http://frees.io/docs/rpc/",
+    "// Read more at: http://frees.io/docs/rpc",
     "",
     "syntax = \"proto3\";",
     ""

--- a/modules/idlgen/core/src/test/resources/proto/GreeterService.proto
+++ b/modules/idlgen/core/src/test/resources/proto/GreeterService.proto
@@ -1,6 +1,6 @@
 // This file has been automatically generated for use by
 // the idlGen plugin, from frees-rpc service definitions.
-// Read more at: http://frees.io/docs/rpc/
+// Read more at: http://frees.io/docs/rpc
 
 syntax = "proto3";
 

--- a/modules/idlgen/core/src/test/scala/IdlGenTests.scala
+++ b/modules/idlgen/core/src/test/scala/IdlGenTests.scala
@@ -70,7 +70,7 @@ class IdlGenTests extends RpcBaseTestSuite {
     }
   }
 
-  "$Generator.generateFrom()" should {
+  "Generator.generateFrom()" should {
     "generate correct Protobuf syntax from RPC definitions" in {
       val expected = resource("/proto/GreeterService.proto").getLines.toList
       val output = Generator.generateFrom(greeterRpcs)

--- a/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/basic/.gitignore
+++ b/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/basic/.gitignore
@@ -1,1 +1,2 @@
 src/main/resources/proto/
+src/main/resources/avro/

--- a/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/basic/test
+++ b/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/basic/test
@@ -3,3 +3,7 @@
 $ exists src/main/resources/proto/model.proto
 
 $ delete src/main/resources/proto/model.proto
+
+$ exists src/main/resources/avro/model.avpr
+
+$ delete src/main/resources/avro/model.avpr


### PR DESCRIPTION
- Fixes broken link in `.proto` headers and associated docs
- Fixes wrong `@option` statements in docs
- Adds `.avpr` generation to plugin test
- Misc testing and docs fixes