### PR TITLE
Releases the plugin first, then the core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,8 +60,8 @@ jobs:
               git clean -f;
               git checkout master;
               git pull origin master;
-              sbt release;
               sbt ";project idlgen-sbt;release";
+              sbt release;
               sbt depUpdateDependencyIssues;
             fi
           fi


### PR DESCRIPTION
Just to make the simplest process first.