### PR TITLE
Support for packaged Avdl into jar dependencies

### DIFF
--- a/docs/src/main/tut/idl-generation.md
+++ b/docs/src/main/tut/idl-generation.md
@@ -171,6 +171,28 @@ To use it, run:
 ```bash
 sbt "srcGen avro"
 ```
+
+You could even use `IDL` definitions packaged into artifacts, within your classpath. In that particular situation, you need to setup `srcJarNames`, specifying the artifacts names that will be unzipped to extract the `IDL` files. You need to run:
+```bash
+sbt "srcGenFromJars"
+```
+
+`srcGenFromJars` can very useful when you want to distribute your `IDL` files without binary code (to prevent binary conflicts in clients). In that case, you might want to include some additional settings in the build where your `IDL` files are placed, like for instance:
+```
+//...
+.settings(
+  Seq(
+    publishMavenStyle := true,
+    mappings in (Compile, packageBin) ~= { _.filter(!_._1.getName.endsWith(".class")) },
+    idlType := "avro",
+    srcGenSourceDir := (Compile / resourceDirectory).value,
+    srcGenTargetDir := (Compile / sourceManaged).value / "compiled_avro",
+    sourceGenerators in Compile += (srcGen in Compile).taskValue
+  )
+)
+//...
+```
+
 In the case of the `.avpr` file we generated above, the file `GreeterService.scala` would be generated in `target/scala-2.12/src_managed/main/quickstart`:
 ```
 package quickstart
@@ -193,12 +215,17 @@ You can also integrate this source generation in your compile process by adding 
 ```
 sourceGenerators in Compile += (srcGen in Compile).taskValue)
 ```
+or,
+```
+sourceGenerators in Compile += (srcGenFromJars in Compile).taskValue)
+```
 
 ### Plugin Settings
 
-Just like `idlGen`, `srcGen` has some configurable settings:
+Just like `idlGen`, `srcGen` and `srcGenFromJars` has some configurable settings:
 
 * **`idlType`**: the type of IDL to generate from, currently only `avro`.
+* **`srcJarNames`**: the list of jar names containing the IDL definitions that will be used at compilation time by `srcGenFromJars` to generate the Scala Sources. By default, this sequence is empty.
 * **`srcGenSourceDir`**: the IDL source base directory, where your IDL files are placed. By default: `Compile / resourceDirectory`, typically `src/main/resources/`.
 * **`srcGenTargetDir`**: the Scala target base directory, where the `srcGen` task will write the Scala files in subdirectories/packages based on the namespaces of the IDL files. By default: `Compile / sourceManaged`, typically `target/scala-2.12/src_managed/main/`.
 * **`genOptions`**: additional options to add to the generated `@rpc` annotations, after the IDL type. Currently only supports `"Gzip"`.

--- a/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/srcGenFromJars/build.sbt
+++ b/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/srcGenFromJars/build.sbt
@@ -1,0 +1,38 @@
+lazy val domain = project
+  .in(file("domain"))
+  .settings(name := "domain")
+  .settings(
+    Seq(
+      organization := "foo.bar",
+      organizationName := "Foo Bar",
+      scalaVersion := "2.12.4"
+    ))
+  .settings(version := "1.0.0")
+  .settings(Seq(
+    publishMavenStyle := true,
+    mappings in (Compile, packageBin) ~= { _.filter(!_._1.getName.endsWith(".class")) },
+    idlType := "avro",
+    srcGenSourceDir := (Compile / resourceDirectory).value,
+    srcGenTargetDir := (Compile / sourceManaged).value / "compiled_avro",
+    sourceGenerators in Compile += (srcGen in Compile).taskValue,
+    libraryDependencies ++= Seq(
+      "com.chuusai" %% "shapeless" % "2.3.2"
+    )
+  ))
+
+lazy val root = project
+  .in(file("."))
+  .settings(name := "root")
+  .settings(Seq(
+    version := sys.props("version"),
+    resolvers += Resolver.bintrayRepo("beyondthelines", "maven"),
+    idlType := "avro",
+    srcJarNames := Seq("domain"),
+    srcGenSourceDir := (Compile / sourceManaged).value / "avro",
+    srcGenTargetDir := (Compile / sourceManaged).value / "compiled_avro",
+    sourceGenerators in Compile += (srcGenFromJars in Compile).taskValue,
+    libraryDependencies ++= Seq(
+      "foo.bar" %% "domain" % "1.0.0",
+      "io.frees" %% "frees-rpc-server" % sys.props("version")
+    )
+  ))

--- a/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/srcGenFromJars/domain/src/main/resources/Hello.avdl
+++ b/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/srcGenFromJars/domain/src/main/resources/Hello.avdl
@@ -1,0 +1,16 @@
+@namespace("foo.bar")
+protocol Hello {
+
+  record HelloRequest {
+    string arg1;
+    union { null, string } arg2;
+    array<string> arg3;
+  }
+
+  record HelloResponse {
+    string arg1;
+    union { null, string } arg2;
+    array<string>  arg3;
+  }
+
+}

--- a/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/srcGenFromJars/project/build.properties
+++ b/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/srcGenFromJars/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.1.2

--- a/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/srcGenFromJars/project/plugins.sbt
+++ b/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/srcGenFromJars/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("io.frees" %% "sbt-frees-rpc-idlgen" % sys.props("version"))

--- a/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/srcGenFromJars/test
+++ b/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/srcGenFromJars/test
@@ -1,0 +1,8 @@
+> domain/compile
+$ exists domain/target/scala-2.12/src_managed/main/compiled_avro/foo/bar/Hello.scala
+> domain/publishLocal
+
+> compile
+$ exists target/scala-2.12/src_managed/main/avro/Hello.avdl
+$ exists target/scala-2.12/src_managed/main/compiled_avro/foo/bar/Hello.scala
+$ delete target/scala-2.12/src_managed/main/compiled_avro/foo/bar/Hello.scala

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.13.1-SNAPSHOT"
+version in ThisBuild := "0.13.1"


### PR DESCRIPTION
This PR provides a new Sbt task as part of the `IDL` plugin, `srcGenFromJars`. 

This new task can very useful when you want to distribute your `IDL` files without binary code (to prevent binary conflicts in clients).

It also adds a new Sbt setting, `srcJarNames`, containing all the artifacts that need to be unzipped to extract the different IDL files.

* [*] Scripted test.
* [*] Update docs.