### PR TITLE
Spins up gRPC Servers forName

### DIFF
--- a/modules/server/src/test/scala/avro/Utils.scala
+++ b/modules/server/src/test/scala/avro/Utils.scala
@@ -20,7 +20,6 @@ package avro
 import freestyle.rpc.common._
 import freestyle.rpc.protocol._
 import cats.effect.Effect
-import io.grpc.ServerServiceDefinition
 import shapeless.{:+:, CNil, Coproduct}
 
 object Utils extends CommonUtils {
@@ -248,7 +247,6 @@ object Utils extends CommonUtils {
   trait FreesRuntime {
 
     import handlers._
-    import freestyle.rpc.server._
 
     //////////////////////////////////
     // Server Runtime Configuration //
@@ -296,38 +294,6 @@ object Utils extends CommonUtils {
     implicit val responseDroppedFieldRPCServiceHandler: serviceResponseDroppedField.RPCService[
       ConcurrentMonad] =
       new ResponseDroppedFieldRPCServiceHandler[ConcurrentMonad]
-
-    val rpcServiceDef: ServerServiceDefinition = service.RPCService.bindService[ConcurrentMonad]
-
-    val rpcServiceRequestAddedBooleanDef: ServerServiceDefinition =
-      serviceRequestAddedBoolean.RPCService.bindService[ConcurrentMonad]
-
-    val rpcServiceRequestAddedStringDef: ServerServiceDefinition =
-      serviceRequestAddedString.RPCService.bindService[ConcurrentMonad]
-
-    val rpcServiceRequestAddedIntDef: ServerServiceDefinition =
-      serviceRequestAddedInt.RPCService.bindService[ConcurrentMonad]
-
-    val rpcServiceRequestAddedNestedRequestDef: ServerServiceDefinition =
-      serviceRequestAddedNestedRequest.RPCService.bindService[ConcurrentMonad]
-
-    val rpcServiceRequestDroppedFieldDef: ServerServiceDefinition =
-      serviceRequestDroppedField.RPCService.bindService[ConcurrentMonad]
-
-    val rpcServiceResponseAddedBooleanDef: ServerServiceDefinition =
-      serviceResponseAddedBoolean.RPCService.bindService[ConcurrentMonad]
-
-    val rpcServiceResponseAddedStringDef: ServerServiceDefinition =
-      serviceResponseAddedString.RPCService.bindService[ConcurrentMonad]
-
-    val rpcServiceResponseAddedIntDef: ServerServiceDefinition =
-      serviceResponseAddedInt.RPCService.bindService[ConcurrentMonad]
-
-    val rpcServiceResponseAddedNestedResponseDef: ServerServiceDefinition =
-      serviceResponseAddedNestedResponse.RPCService.bindService[ConcurrentMonad]
-
-    val rpcServiceResponseDroppedFieldDef: ServerServiceDefinition =
-      serviceResponseDroppedField.RPCService.bindService[ConcurrentMonad]
 
     //////////////////////////////////
     // Client Runtime Configuration //

--- a/modules/server/src/test/scala/avro/Utils.scala
+++ b/modules/server/src/test/scala/avro/Utils.scala
@@ -20,6 +20,7 @@ package avro
 import freestyle.rpc.common._
 import freestyle.rpc.protocol._
 import cats.effect.Effect
+import io.grpc.ServerServiceDefinition
 import shapeless.{:+:, CNil, Coproduct}
 
 object Utils extends CommonUtils {
@@ -296,49 +297,37 @@ object Utils extends CommonUtils {
       ConcurrentMonad] =
       new ResponseDroppedFieldRPCServiceHandler[ConcurrentMonad]
 
-    val rpcServiceConfigs: List[GrpcConfig] = List(
-      AddService(service.RPCService.bindService[ConcurrentMonad])
-    )
+    val rpcServiceDef: ServerServiceDefinition = service.RPCService.bindService[ConcurrentMonad]
 
-    val rpcServiceRequestAddedBooleanConfigs: List[GrpcConfig] = List(
-      AddService(serviceRequestAddedBoolean.RPCService.bindService[ConcurrentMonad])
-    )
+    val rpcServiceRequestAddedBooleanDef: ServerServiceDefinition =
+      serviceRequestAddedBoolean.RPCService.bindService[ConcurrentMonad]
 
-    val rpcServiceRequestAddedStringConfigs: List[GrpcConfig] = List(
-      AddService(serviceRequestAddedString.RPCService.bindService[ConcurrentMonad])
-    )
+    val rpcServiceRequestAddedStringDef: ServerServiceDefinition =
+      serviceRequestAddedString.RPCService.bindService[ConcurrentMonad]
 
-    val rpcServiceRequestAddedIntConfigs: List[GrpcConfig] = List(
-      AddService(serviceRequestAddedInt.RPCService.bindService[ConcurrentMonad])
-    )
+    val rpcServiceRequestAddedIntDef: ServerServiceDefinition =
+      serviceRequestAddedInt.RPCService.bindService[ConcurrentMonad]
 
-    val rpcServiceRequestAddedNestedRequestConfigs: List[GrpcConfig] = List(
-      AddService(serviceRequestAddedNestedRequest.RPCService.bindService[ConcurrentMonad])
-    )
+    val rpcServiceRequestAddedNestedRequestDef: ServerServiceDefinition =
+      serviceRequestAddedNestedRequest.RPCService.bindService[ConcurrentMonad]
 
-    val rpcServiceRequestDroppedFieldConfigs: List[GrpcConfig] = List(
-      AddService(serviceRequestDroppedField.RPCService.bindService[ConcurrentMonad])
-    )
+    val rpcServiceRequestDroppedFieldDef: ServerServiceDefinition =
+      serviceRequestDroppedField.RPCService.bindService[ConcurrentMonad]
 
-    val rpcServiceResponseAddedBooleanConfigs: List[GrpcConfig] = List(
-      AddService(serviceResponseAddedBoolean.RPCService.bindService[ConcurrentMonad])
-    )
+    val rpcServiceResponseAddedBooleanDef: ServerServiceDefinition =
+      serviceResponseAddedBoolean.RPCService.bindService[ConcurrentMonad]
 
-    val rpcServiceResponseAddedStringConfigs: List[GrpcConfig] = List(
-      AddService(serviceResponseAddedString.RPCService.bindService[ConcurrentMonad])
-    )
+    val rpcServiceResponseAddedStringDef: ServerServiceDefinition =
+      serviceResponseAddedString.RPCService.bindService[ConcurrentMonad]
 
-    val rpcServiceResponseAddedIntConfigs: List[GrpcConfig] = List(
-      AddService(serviceResponseAddedInt.RPCService.bindService[ConcurrentMonad])
-    )
+    val rpcServiceResponseAddedIntDef: ServerServiceDefinition =
+      serviceResponseAddedInt.RPCService.bindService[ConcurrentMonad]
 
-    val rpcServiceResponseAddedNestedResponseConfigs: List[GrpcConfig] = List(
-      AddService(serviceResponseAddedNestedResponse.RPCService.bindService[ConcurrentMonad])
-    )
+    val rpcServiceResponseAddedNestedResponseDef: ServerServiceDefinition =
+      serviceResponseAddedNestedResponse.RPCService.bindService[ConcurrentMonad]
 
-    val rpcServiceResponseDroppedFieldConfigs: List[GrpcConfig] = List(
-      AddService(serviceResponseDroppedField.RPCService.bindService[ConcurrentMonad])
-    )
+    val rpcServiceResponseDroppedFieldDef: ServerServiceDefinition =
+      serviceResponseDroppedField.RPCService.bindService[ConcurrentMonad]
 
     //////////////////////////////////
     // Client Runtime Configuration //

--- a/modules/testing/src/test/scala/ServerChannel.scala
+++ b/modules/testing/src/test/scala/ServerChannel.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc
+package testing
+
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+
+import io.grpc.{ManagedChannel, Server, ServerServiceDefinition}
+import io.grpc.inprocess.{InProcessChannelBuilder, InProcessServerBuilder}
+import io.grpc.util.MutableHandlerRegistry
+
+final case class ServerChannel(server: Server, channel: ManagedChannel) {
+
+  def shutdown: Boolean = {
+    channel.shutdown
+    server.shutdown
+
+    try {
+      channel.awaitTermination(1, TimeUnit.MINUTES)
+      server.awaitTermination(1, TimeUnit.MINUTES)
+    } catch {
+      case e: InterruptedException =>
+        Thread.currentThread.interrupt()
+        throw new RuntimeException(e)
+    } finally {
+      channel.shutdownNow
+      server.shutdownNow
+      (): Unit
+    }
+  }
+}
+
+object ServerChannel {
+
+  def apply(serverServiceDefinitions: ServerServiceDefinition*): ServerChannel = {
+    val serviceRegistry =
+      new MutableHandlerRegistry
+    val serverName: String =
+      UUID.randomUUID.toString
+    val serverBuilder: InProcessServerBuilder =
+      InProcessServerBuilder
+        .forName(serverName)
+        .fallbackHandlerRegistry(serviceRegistry)
+        .directExecutor()
+    val channelBuilder: InProcessChannelBuilder =
+      InProcessChannelBuilder.forName(serverName)
+
+    serverServiceDefinitions.toList.map(serverBuilder.addService)
+
+    ServerChannel(serverBuilder.build().start(), channelBuilder.directExecutor.build)
+  }
+
+  def WithServerChannel[A](ssds: ServerServiceDefinition*)(f: ServerChannel => A): A = {
+
+    val sc: ServerChannel = apply(ssds: _*)
+    val result: A         = f(sc)
+    sc.shutdown
+
+    result
+  }
+
+}

--- a/modules/testing/src/test/scala/ServerChannel.scala
+++ b/modules/testing/src/test/scala/ServerChannel.scala
@@ -26,9 +26,9 @@ import io.grpc.util.MutableHandlerRegistry
 
 final case class ServerChannel(server: Server, channel: ManagedChannel) {
 
-  def shutdown: Boolean = {
-    channel.shutdown
-    server.shutdown
+  def shutdown(): Boolean = {
+    channel.shutdown()
+    server.shutdown()
 
     try {
       channel.awaitTermination(1, TimeUnit.MINUTES)
@@ -38,8 +38,8 @@ final case class ServerChannel(server: Server, channel: ManagedChannel) {
         Thread.currentThread.interrupt()
         throw new RuntimeException(e)
     } finally {
-      channel.shutdownNow
-      server.shutdownNow
+      channel.shutdownNow()
+      server.shutdownNow()
       (): Unit
     }
   }
@@ -65,11 +65,11 @@ object ServerChannel {
     ServerChannel(serverBuilder.build().start(), channelBuilder.directExecutor.build)
   }
 
-  def WithServerChannel[A](ssds: ServerServiceDefinition*)(f: ServerChannel => A): A = {
+  def withServerChannel[A](services: ServerServiceDefinition*)(f: ServerChannel => A): A = {
 
-    val sc: ServerChannel = apply(ssds: _*)
+    val sc: ServerChannel = apply(services: _*)
     val result: A         = f(sc)
-    sc.shutdown
+    sc.shutdown()
 
     result
   }


### PR DESCRIPTION
This PR solves some random issues at `freestyle.rpc.avro.RPCTests`, providing a new `ServerChannel` utility bringing the ability to bootstrap gRPC Servers using `InProcessServerBuilder`:

> Builder for a server that services in-process requests. Clients identify the in-process server by its name. The server is intended to be fully-featured, high performance, and useful in testing.

Related to #227 