### PR TITLE
Create example route guide client module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -202,6 +202,7 @@ lazy val `example-routeguide-server` = project
   .dependsOn(`example-routeguide-runtime`)
   .dependsOn(server)
   .settings(moduleName := "frees-rpc-example-routeguide-server")
+  .settings(addCommandAlias("runServer", "runMain routeguide.ServerApp"))
   .disablePlugins(ScriptedPlugin)
 
 lazy val `example-routeguide-client` = project
@@ -216,6 +217,8 @@ lazy val `example-routeguide-client` = project
       baseDirectory.value / "src" / "main" / "task"
     )
   )
+  .settings(addCommandAlias("runClientIO", "runMain routeguide.ClientAppIO"))
+  .settings(addCommandAlias("runClientTask", "runMain routeguide.ClientAppTask"))
   .disablePlugins(ScriptedPlugin)
 
 //////////////////////////

--- a/build.sbt
+++ b/build.sbt
@@ -210,6 +210,12 @@ lazy val `example-routeguide-client` = project
   .dependsOn(`example-routeguide-runtime`)
   .dependsOn(`client-netty`)
   .settings(moduleName := "frees-rpc-example-routeguide-client")
+  .settings(
+    Compile / unmanagedSourceDirectories ++= Seq(
+      baseDirectory.value / "src" / "main" / "io",
+      baseDirectory.value / "src" / "main" / "task"
+    )
+  )
   .disablePlugins(ScriptedPlugin)
 
 //////////////////////////

--- a/build.sbt
+++ b/build.sbt
@@ -202,7 +202,6 @@ lazy val `example-routeguide-server` = project
   .dependsOn(`example-routeguide-runtime`)
   .dependsOn(server)
   .settings(moduleName := "frees-rpc-example-routeguide-server")
-  .settings(addCommandAlias("runServer", "runMain routeguide.ServerApp"))
   .disablePlugins(ScriptedPlugin)
 
 lazy val `example-routeguide-client` = project
@@ -217,8 +216,8 @@ lazy val `example-routeguide-client` = project
       baseDirectory.value / "src" / "main" / "task"
     )
   )
-  .settings(addCommandAlias("runClientIO", "runMain routeguide.ClientAppIO"))
-  .settings(addCommandAlias("runClientTask", "runMain routeguide.ClientAppTask"))
+  .settings(addCommandAlias("runClientIO", "runMain example.routeguide.client.io.ClientAppIO"))
+  .settings(addCommandAlias("runClientTask", "runMain example.routeguide.client.task.ClientAppTask"))
   .disablePlugins(ScriptedPlugin)
 
 //////////////////////////

--- a/modules/examples/routeguide/client/src/main/resources/application.conf
+++ b/modules/examples/routeguide/client/src/main/resources/application.conf
@@ -1,0 +1,8 @@
+rpc {
+  client {
+    host = "localhost"
+    host = ${?RPC_HOST}
+    port = 50051
+    port = ${?RPC_PORT}
+  }
+}

--- a/modules/examples/routeguide/client/src/main/scala/ClientProgram.scala
+++ b/modules/examples/routeguide/client/src/main/scala/ClientProgram.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package example.routeguide.client
+
+import cats.Monad
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import freestyle.tagless._
+import example.routeguide.protocol.Protocols._
+import example.routeguide.common.Utils
+
+@tagless(false)
+trait RouteGuideClient[F[_]] {
+  def getFeature(lat: Int, lon: Int): F[Unit]
+  def listFeatures(lowLat: Int, lowLon: Int, hiLat: Int, hiLon: Int): F[Unit]
+  def recordRoute(features: List[Feature], numPoints: Int): F[Unit]
+  def routeChat: F[Unit]
+}
+
+object ClientProgram {
+
+  def clientProgram[M[_]: Monad](implicit APP: RouteGuideClient[M]): M[Unit] = {
+    for {
+      // Looking for a valid feature
+      _ <- APP.getFeature(409146138, -746188906)
+      // Feature missing.
+      _ <- APP.getFeature(0, 0)
+      // Looking for features between 40, -75 and 42, -73.
+      _ <- APP.listFeatures(400000000, -750000000, 420000000, -730000000)
+      // Record a few randomly selected points from the features file.
+      _ <- APP.recordRoute(Utils.features, 50)
+      // Send and receive some notes.
+      _ <- APP.routeChat
+    } yield ()
+  }
+}

--- a/modules/examples/routeguide/client/src/main/scala/ClientProgram.scala
+++ b/modules/examples/routeguide/client/src/main/scala/ClientProgram.scala
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package example.routeguide.client
 
 import cats.Monad

--- a/modules/examples/routeguide/client/src/main/scala/ClientProgram.scala
+++ b/modules/examples/routeguide/client/src/main/scala/ClientProgram.scala
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package example.routeguide.client
 
 import cats.Monad

--- a/modules/examples/routeguide/client/src/main/scala/handlers/RouteGuideClientHandler.scala
+++ b/modules/examples/routeguide/client/src/main/scala/handlers/RouteGuideClientHandler.scala
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package example.routeguide.client.handlers
+
+import cats._
+import cats.implicits._
+import example.routeguide.client.RouteGuideClient
+import io.grpc.{Status, StatusRuntimeException}
+import monix.eval.Task
+import monix.reactive.Observable
+import org.log4s._
+import example.routeguide.protocol.Protocols._
+import example.routeguide.common.Utils._
+
+import scala.concurrent.duration._
+
+class RouteGuideClientHandler[F[_]: Monad](
+    implicit client: RouteGuideService.Client[F],
+    M: MonadError[F, Throwable],
+    T2F: Task ~> F)
+    extends RouteGuideClient.Handler[F] {
+
+  val logger = getLogger
+
+  override def getFeature(lat: Int, lon: Int): F[Unit] =
+    M.handleErrorWith {
+      logger.info(s"*** GetFeature: lat=$lat lon=$lon")
+      client
+        .getFeature(Point(lat, lon))
+        .map { feature: Feature =>
+          if (feature.valid)
+            logger.info(s"Found feature called '${feature.name}' at ${feature.location.pretty}")
+          else logger.info(s"Found no feature at ${feature.location.pretty}")
+        }
+    } {
+      case e: StatusRuntimeException =>
+        logger.warn(s"RPC failed:${e.getStatus} $e")
+        M.raiseError(e)
+    }
+
+  override def listFeatures(lowLat: Int, lowLon: Int, hiLat: Int, hiLon: Int): F[Unit] = T2F.apply {
+    logger.info(s"*** ListFeatures: lowLat=$lowLat lowLon=$lowLon hiLat=$hiLat hiLon=$hiLon")
+    client
+      .listFeatures(
+        Rectangle(
+          lo = Point(lowLat, lowLon),
+          hi = Point(hiLat, hiLon)
+        ))
+      .zipWithIndex
+      .map {
+        case (feature, i) =>
+          logger.info(s"Result #$i: $feature")
+      }
+      .onErrorHandle {
+        case e: StatusRuntimeException =>
+          logger.warn(s"RPC failed: ${e.getStatus} $e")
+          throw e
+      }
+      .completedL
+  }
+
+  override def recordRoute(features: List[Feature], numPoints: Int): F[Unit] = {
+    def takeN: List[Feature] = scala.util.Random.shuffle(features).take(numPoints)
+
+    M.handleErrorWith {
+      val points = takeN.map(_.location)
+      logger.info(s"*** RecordRoute. Points: ${points.map(_.pretty).mkString(";")}")
+
+      client
+        .recordRoute(
+          Observable
+            .fromIterable(points)
+            .delayOnNext(500.milliseconds))
+        .map { summary: RouteSummary =>
+          logger.info(
+            s"Finished trip with ${summary.point_count} points. Passed ${summary.feature_count} features. " +
+              s"Travelled ${summary.distance} meters. It took ${summary.elapsed_time} seconds.")
+        }
+    } { e: Throwable =>
+      logger.warn(s"RecordRoute Failed: ${Status.fromThrowable(e)} $e")
+      M.raiseError(e)
+    }
+  }
+
+  override def routeChat: F[Unit] = T2F.apply {
+    logger.info("*** RouteChat")
+    client
+      .routeChat(
+        Observable
+          .fromIterable(List(
+            RouteNote(message = "First message", location = Point(0, 0)),
+            RouteNote(message = "Second message", location = Point(0, 1)),
+            RouteNote(message = "Third message", location = Point(1, 0)),
+            RouteNote(message = "Fourth message", location = Point(1, 1))
+          ))
+          .delayOnNext(10.milliseconds)
+          .map { routeNote =>
+            logger.info(s"Sending message '${routeNote.message}' at " +
+              s"${routeNote.location.latitude}, ${routeNote.location.longitude}")
+            routeNote
+          }
+      )
+      .map { note: RouteNote =>
+        logger.info(s"Got message '${note.message}' at " +
+          s"${note.location.latitude}, ${note.location.longitude}")
+      }
+      .onErrorHandle {
+        case e: Throwable =>
+          logger.warn(s"RouteChat Failed: ${Status.fromThrowable(e)} $e")
+          throw e
+      }
+      .completedL
+  }
+
+}

--- a/modules/examples/routeguide/client/src/main/scala/handlers/RouteGuideClientHandler.scala
+++ b/modules/examples/routeguide/client/src/main/scala/handlers/RouteGuideClientHandler.scala
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package example.routeguide.client.handlers
 
 import cats._

--- a/modules/examples/routeguide/client/src/main/scala/handlers/RouteGuideClientHandler.scala
+++ b/modules/examples/routeguide/client/src/main/scala/handlers/RouteGuideClientHandler.scala
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package example.routeguide.client.handlers
 
 import cats._

--- a/modules/examples/routeguide/client/src/main/scala/io/ClientAppIO.scala
+++ b/modules/examples/routeguide/client/src/main/scala/io/ClientAppIO.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package example.routeguide.client.io
+
+import cats.effect.IO
+import org.log4s._
+import example.routeguide.client.io.clientIO.implicits._
+import example.routeguide.client.ClientProgram._
+
+object ClientAppIO {
+
+  def main(args: Array[String]): Unit = {
+
+    val logger = getLogger
+
+    logger.info(s"${Thread.currentThread().getName} Starting client, interpreting to Future ...")
+
+    clientProgram[IO].unsafeRunSync()
+
+    logger.info(s"${Thread.currentThread().getName} Finishing program interpretation ...")
+
+    (): Unit
+    System.in.read()
+  }
+
+}

--- a/modules/examples/routeguide/client/src/main/scala/io/ClientAppIO.scala
+++ b/modules/examples/routeguide/client/src/main/scala/io/ClientAppIO.scala
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package example.routeguide.client.io
 
 import cats.effect.IO
 import org.log4s._
-import example.routeguide.client.io.clientIO.implicits._
+import example.routeguide.client.io.implicits._
 import example.routeguide.client.ClientProgram._
 
 object ClientAppIO {

--- a/modules/examples/routeguide/client/src/main/scala/io/ClientAppIO.scala
+++ b/modules/examples/routeguide/client/src/main/scala/io/ClientAppIO.scala
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package example.routeguide.client.io
 
 import cats.effect.IO

--- a/modules/examples/routeguide/client/src/main/scala/io/ClientIO.scala
+++ b/modules/examples/routeguide/client/src/main/scala/io/ClientIO.scala
@@ -22,17 +22,12 @@ import example.routeguide.protocol.Protocols._
 import example.routeguide.runtime._
 import example.routeguide.client.runtime._
 
-object clientIO {
+trait Implicits extends RouteGuide with ClientConf {
 
-  trait Implicits extends RouteGuide with ClientConf {
+  implicit val routeGuideServiceClient: RouteGuideService.Client[IO] =
+    RouteGuideService.client[IO](channelFor)
 
-    implicit val routeGuideServiceClient: RouteGuideService.Client[IO] =
-      RouteGuideService.client[IO](channelFor)
-
-    implicit val routeGuideClientHandler: RouteGuideClientHandler[IO] =
-      new RouteGuideClientHandler[IO]
-  }
-
-  object implicits extends Implicits
-
+  implicit val routeGuideClientHandler: RouteGuideClientHandler[IO] =
+    new RouteGuideClientHandler[IO]
 }
+object implicits extends Implicits

--- a/modules/examples/routeguide/client/src/main/scala/io/ClientIO.scala
+++ b/modules/examples/routeguide/client/src/main/scala/io/ClientIO.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package example.routeguide.client.io
+
+import cats.effect.IO
+import example.routeguide.client.handlers.RouteGuideClientHandler
+import example.routeguide.protocol.Protocols._
+import example.routeguide.runtime._
+import example.routeguide.client.runtime._
+
+object clientIO {
+
+  trait Implicits extends RouteGuide with ClientConf {
+
+    implicit val routeGuideServiceClient: RouteGuideService.Client[IO] =
+      RouteGuideService.client[IO](channelFor)
+
+    implicit val routeGuideClientHandler: RouteGuideClientHandler[IO] =
+      new RouteGuideClientHandler[IO]
+  }
+
+  object implicits extends Implicits
+
+}

--- a/modules/examples/routeguide/client/src/main/scala/runtime/ClientConf.scala
+++ b/modules/examples/routeguide/client/src/main/scala/runtime/ClientConf.scala
@@ -14,6 +14,16 @@
  * limitations under the License.
  */
 
-package example.routeguide.client
+package example.routeguide.client.runtime
 
-class Client {}
+import cats.effect.IO
+import freestyle.rpc.ChannelFor
+import freestyle.rpc.client.config.ConfigForAddress
+import freestyle.tagless.config.implicits._
+
+trait ClientConf {
+
+  val channelFor: ChannelFor =
+    ConfigForAddress[IO]("rpc.client.host", "rpc.client.port").unsafeRunSync()
+
+}

--- a/modules/examples/routeguide/client/src/main/scala/runtime/ClientConf.scala
+++ b/modules/examples/routeguide/client/src/main/scala/runtime/ClientConf.scala
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package example.routeguide.client.runtime
 
 import cats.effect.IO

--- a/modules/examples/routeguide/client/src/main/scala/runtime/ClientConf.scala
+++ b/modules/examples/routeguide/client/src/main/scala/runtime/ClientConf.scala
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package example.routeguide.client.runtime
 
 import cats.effect.IO

--- a/modules/examples/routeguide/client/src/main/scala/task/ClientAppTask.scala
+++ b/modules/examples/routeguide/client/src/main/scala/task/ClientAppTask.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package example.routeguide.client.task
+
+import monix.eval.Task
+import org.log4s._
+import example.routeguide.client.ClientProgram._
+import example.routeguide.client.task.clientTask.implicits._
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+object ClientAppTask {
+
+  def main(args: Array[String]): Unit = {
+
+    val logger = getLogger
+
+    logger.info(s"${Thread.currentThread().getName} Starting client, interpreting to Task ...")
+
+    Await.result(clientProgram[Task].runAsync, Duration.Inf)
+
+    logger.info(s"${Thread.currentThread().getName} Finishing program interpretation ...")
+
+    (): Unit
+    System.in.read()
+  }
+
+}

--- a/modules/examples/routeguide/client/src/main/scala/task/ClientAppTask.scala
+++ b/modules/examples/routeguide/client/src/main/scala/task/ClientAppTask.scala
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package example.routeguide.client.task
 
 import monix.eval.Task

--- a/modules/examples/routeguide/client/src/main/scala/task/ClientAppTask.scala
+++ b/modules/examples/routeguide/client/src/main/scala/task/ClientAppTask.scala
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package example.routeguide.client.task
 
 import monix.eval.Task
 import org.log4s._
 import example.routeguide.client.ClientProgram._
-import example.routeguide.client.task.clientTask.implicits._
+import example.routeguide.client.task.implicits._
 import scala.concurrent.Await
 import scala.concurrent.duration._
 

--- a/modules/examples/routeguide/client/src/main/scala/task/ClientTask.scala
+++ b/modules/examples/routeguide/client/src/main/scala/task/ClientTask.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package example.routeguide.client.task
+
+import example.routeguide.client.handlers.RouteGuideClientHandler
+import example.routeguide.protocol.Protocols._
+import example.routeguide.runtime._
+import example.routeguide.client.runtime._
+import monix.eval.Task
+
+object clientTask {
+
+  trait Implicits extends RouteGuide with ClientConf {
+
+    implicit val routeGuideServiceClient: RouteGuideService.Client[Task] =
+      RouteGuideService.client[Task](channelFor)
+
+    implicit val routeGuideClientHandler: RouteGuideClientHandler[Task] =
+      new RouteGuideClientHandler[Task]
+  }
+
+  object implicits extends Implicits
+
+}

--- a/modules/examples/routeguide/client/src/main/scala/task/ClientTask.scala
+++ b/modules/examples/routeguide/client/src/main/scala/task/ClientTask.scala
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package example.routeguide.client.task
 
 import example.routeguide.client.handlers.RouteGuideClientHandler

--- a/modules/examples/routeguide/client/src/main/scala/task/ClientTask.scala
+++ b/modules/examples/routeguide/client/src/main/scala/task/ClientTask.scala
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package example.routeguide.client.task
 
 import example.routeguide.client.handlers.RouteGuideClientHandler
@@ -22,17 +21,13 @@ import example.routeguide.runtime._
 import example.routeguide.client.runtime._
 import monix.eval.Task
 
-object clientTask {
+trait Implicits extends RouteGuide with ClientConf {
 
-  trait Implicits extends RouteGuide with ClientConf {
+  implicit val routeGuideServiceClient: RouteGuideService.Client[Task] =
+    RouteGuideService.client[Task](channelFor)
 
-    implicit val routeGuideServiceClient: RouteGuideService.Client[Task] =
-      RouteGuideService.client[Task](channelFor)
-
-    implicit val routeGuideClientHandler: RouteGuideClientHandler[Task] =
-      new RouteGuideClientHandler[Task]
-  }
-
-  object implicits extends Implicits
-
+  implicit val routeGuideClientHandler: RouteGuideClientHandler[Task] =
+    new RouteGuideClientHandler[Task]
 }
+
+object implicits extends Implicits


### PR DESCRIPTION
This pr add the client module to the route guide example
The client module includes an IO and Task client with Freestyle-RPC
Fixes: #221 