### PR TITLE
SBT - Adds AvroWithSchema Support

### DIFF
--- a/docs/src/main/tut/idl-generation.md
+++ b/docs/src/main/tut/idl-generation.md
@@ -225,6 +225,7 @@ sourceGenerators in Compile += (srcGenFromJars in Compile).taskValue)
 Just like `idlGen`, `srcGen` and `srcGenFromJars` has some configurable settings:
 
 * **`idlType`**: the type of IDL to generate from, currently only `avro`.
+* **`srcGenSerializationType`**: the serialization type when generating Scala sources from the IDL definitions. `Protobuf`, `Avro` or `AvroWithSchema` are the current supported serialization types. By default, the serialization type is `Avro`.
 * **`srcJarNames`**: the list of jar names containing the IDL definitions that will be used at compilation time by `srcGenFromJars` to generate the Scala Sources. By default, this sequence is empty.
 * **`srcGenSourceDir`**: the IDL source base directory, where your IDL files are placed. By default: `Compile / resourceDirectory`, typically `src/main/resources/`.
 * **`srcGenTargetDir`**: the Scala target base directory, where the `srcGen` task will write the Scala files in subdirectories/packages based on the namespaces of the IDL files. By default: `Compile / sourceManaged`, typically `target/scala-2.12/src_managed/main/`.

--- a/modules/idlgen/core/src/main/scala/Generator.scala
+++ b/modules/idlgen/core/src/main/scala/Generator.scala
@@ -22,14 +22,20 @@ trait Generator {
 
   def idlType: String
 
-  def generateFrom(files: Set[File], options: String*): Seq[(File, String, Seq[String])] =
+  def generateFrom(
+      files: Set[File],
+      serializationType: String,
+      options: String*): Seq[(File, String, Seq[String])] =
     inputFiles(files).flatMap(inputFile =>
-      generateFrom(inputFile, options: _*).map {
+      generateFrom(inputFile, serializationType, options: _*).map {
         case (outputPath, output) =>
           (inputFile, outputPath, output)
     })
 
   protected def inputFiles(files: Set[File]): Seq[File]
 
-  protected def generateFrom(inputFile: File, options: String*): Option[(String, Seq[String])]
+  protected def generateFrom(
+      inputFile: File,
+      serializationType: String,
+      options: String*): Option[(String, Seq[String])]
 }

--- a/modules/idlgen/core/src/main/scala/IdlGenerator.scala
+++ b/modules/idlgen/core/src/main/scala/IdlGenerator.scala
@@ -29,7 +29,10 @@ trait IdlGenerator extends Generator {
   def inputFiles(files: Set[File]): Seq[File] =
     files.filter(_.getName.endsWith(ScalaFileExtension)).toSeq
 
-  def generateFrom(inputFile: File, options: String*): Option[(String, Seq[String])] = {
+  def generateFrom(
+      inputFile: File,
+      serializationType: String,
+      options: String*): Option[(String, Seq[String])] = {
     val inputName   = inputFile.getName.replaceAll(ScalaFileExtension, "")
     val definitions = ScalaParser.parse(inputFile.parse[Source].get, inputName)
     generateFrom(definitions).map(output => s"$outputSubdir/$inputName$fileExtension" -> output)

--- a/modules/idlgen/core/src/main/scala/idlgen.scala
+++ b/modules/idlgen/core/src/main/scala/idlgen.scala
@@ -18,6 +18,7 @@ package freestyle.rpc
 
 import freestyle.rpc.idlgen.avro._
 import freestyle.rpc.idlgen.proto.ProtoIdlGenerator
+import freestyle.rpc.protocol.{Avro, AvroWithSchema, Protobuf, SerializationType}
 
 package object idlgen {
 
@@ -33,4 +34,7 @@ package object idlgen {
   val srcGenerators: Map[String, SrcGenerator] = Seq(AvroSrcGenerator)
     .map(g => g.idlType -> g)
     .toMap
+
+  val serializationTypes: Map[String, SerializationType] =
+    Map("Protobuf" -> Protobuf, "Avro" -> Avro, "AvroWithSchema" -> AvroWithSchema)
 }

--- a/modules/idlgen/core/src/test/resources/avro/MyGreeterWithSchemaService.scala
+++ b/modules/idlgen/core/src/test/resources/avro/MyGreeterWithSchemaService.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package foo.bar
+
+import freestyle.rpc.protocol._
+
+@message case class HelloRequest(arg1: String, arg2: Option[String], arg3: List[String])
+
+@message case class HelloResponse(arg1: String, arg2: Option[String], arg3: List[String])
+
+@service trait MyGreeterService[F[_]] {
+
+  @rpc(AvroWithSchema, Gzip)
+  def sayHelloAvro(arg: foo.bar.HelloRequest): F[foo.bar.HelloResponse]
+
+  @rpc(AvroWithSchema, Gzip)
+  def sayNothingAvro(arg: Empty.type): F[Empty.type]
+
+}

--- a/modules/idlgen/core/src/test/scala/SrcGenTests.scala
+++ b/modules/idlgen/core/src/test/scala/SrcGenTests.scala
@@ -33,16 +33,25 @@ class SrcGenTests extends RpcBaseTestSuite {
         "/avro/GreeterService.avdl",
         "/avro/MyGreeterService.scala",
         "foo/bar/MyGreeterService.scala")
+
+    "generate correct Scala classes from .avdl for AvroWithSchema serialization type" in
+      test(
+        "/avro/GreeterService.avdl",
+        "/avro/MyGreeterWithSchemaService.scala",
+        "foo/bar/MyGreeterService.scala",
+        "AvroWithSchema")
   }
 
   private def test(
       inputResourcePath: String,
       outputResourcePath: String,
-      outputFilePath: String): Unit = {
+      outputFilePath: String,
+      serializationType: String = "Avro"): Unit = {
     val expectedOutput = resource(outputResourcePath).getLines.toList
       .dropWhile(line => line.startsWith("/*") || line.startsWith(" *"))
       .tail
-    val output = AvroSrcGenerator.generateFrom(resource(inputResourcePath).mkString, "Gzip")
+    val output =
+      AvroSrcGenerator.generateFrom(resource(inputResourcePath).mkString, serializationType, "Gzip")
     output should not be empty
     val (filePath, contents) = output.get
     filePath shouldBe outputFilePath

--- a/modules/idlgen/plugin/src/main/scala/IdlGenPlugin.scala
+++ b/modules/idlgen/plugin/src/main/scala/IdlGenPlugin.scala
@@ -52,7 +52,7 @@ object IdlGenPlugin extends AutoPlugin {
       settingKey[String](
         "The serialization type when generating Scala sources from the IDL definitions." +
           "Protobuf, Avro or AvroWithSchema are the current supported serialization types. " +
-          "The serialization type by default is 'Avro'")
+          "By default, the serialization type is 'Avro'.")
 
     lazy val srcGenSourceDir: SettingKey[File] =
       settingKey[File]("The IDL directory, where your IDL definitions are placed.")

--- a/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/avroWithSchema/build.sbt
+++ b/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/avroWithSchema/build.sbt
@@ -1,0 +1,7 @@
+version := sys.props("version")
+
+resolvers += Resolver.bintrayRepo("beyondthelines", "maven")
+
+libraryDependencies ++= Seq(
+  "io.frees" %% "frees-rpc-server" % sys.props("version")
+)

--- a/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/avroWithSchema/project/build.properties
+++ b/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/avroWithSchema/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.1.2

--- a/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/avroWithSchema/project/plugins.sbt
+++ b/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/avroWithSchema/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("io.frees" %% "sbt-frees-rpc-idlgen" % sys.props("version"))

--- a/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/avroWithSchema/src/main/resources/service.avdl
+++ b/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/avroWithSchema/src/main/resources/service.avdl
@@ -1,0 +1,16 @@
+@namespace("io.frees")
+protocol service {
+
+  record Foo {
+    string bar;
+  }
+
+  record Person {
+    long id;
+    string name;
+    union { null, string } email;
+  }
+
+  io.frees.Person hi(io.frees.Foo request);
+
+}

--- a/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/avroWithSchema/test
+++ b/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/avroWithSchema/test
@@ -1,0 +1,12 @@
+$ exists src/main/resources/service.avdl
+> 'set idlType := "avro"'
+> 'set srcGenSerializationType := "Avro"'
+> srcGen
+$ exists target/scala-2.12/src_managed/main/io/frees/service.scala
+$ delete target/scala-2.12/src_managed/main/io/frees/service.scala
+
+$ exists src/main/resources/service.avdl
+> 'set idlType := "avro"'
+> 'set srcGenSerializationType := "AvroWithSchema"'
+> srcGen
+$ exists target/scala-2.12/src_managed/main/io/frees/service.scala


### PR DESCRIPTION
This PR adds support for `AvroWithSchema` serialization type, in the matter of IDL generation. 

Before this PR, only `Avro` was supported. Now, using the new Sbt setting `srcGenSerializationType`, the users can specify if the RPC services will be serializing with `Avro` or `AvroWithSchema` (actually, `AvroWithSchema` was included as part of https://github.com/frees-io/freestyle-rpc/pull/215, in this PR we are just providing the ability to generate Scala Sources based on that serialization type).

* [x] Support for the new feature.
* [x] Unit tests.
* [x] Scripted tests.
* [x] Update docs. 