### PR TITLE
fixing shutdown hook to run shutdown of server

### DIFF
--- a/modules/server/src/main/scala/handlers/GrpcServerHandler.scala
+++ b/modules/server/src/main/scala/handlers/GrpcServerHandler.scala
@@ -27,16 +27,15 @@ import scala.concurrent.duration.TimeUnit
 
 class GrpcServerHandler[F[_]: Applicative] extends GrpcServer.Handler[GrpcServerOps[F, ?]] {
 
-  def start: GrpcServerOps[F, Server] = {
-
+  def start: GrpcServerOps[F, Server] = captureWithServer { server =>
     Runtime.getRuntime.addShutdownHook(new Thread() {
       override def run(): Unit = {
-        shutdown
+        server.shutdown()
         (): Unit
       }
     })
 
-    captureWithServer(_.start())
+    server.start()
   }
 
   def getPort: GrpcServerOps[F, Int] = captureWithServer(_.getPort)


### PR DESCRIPTION
Before this PR, the shutdown hook was ultimately just creating an instance of a Kleisli and returning, without ever actually shutting down the `Server`. This PR corrects that by calling `shutdown` directly on the gRPC `Server`, rather than calling the [`shutdown`](https://github.com/frees-io/freestyle-rpc/compare/master...tyler-clark:shutdown-hook?expand=1#diff-a5d70a63524b8e083da32f9f9c93ca3cR52) method defined within the same class.