### PR TITLE
Adds support for Marshalling/Unmarshalling BigDecimals

### DIFF
--- a/modules/internal/src/main/scala/encoders.scala
+++ b/modules/internal/src/main/scala/encoders.scala
@@ -18,12 +18,27 @@ package freestyle.rpc
 package internal
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream}
-import freestyle.rpc.protocol._
+
 import _root_.io.grpc.MethodDescriptor.Marshaller
+import com.google.common.io.ByteStreams
+import freestyle.rpc.protocol._
+import freestyle.rpc.internal.util.BigDecimalUtil
 
 object encoders {
 
-  object pbd {
+  trait Marshallers {
+
+    implicit val bigDecimalMarshaller: Marshaller[BigDecimal] = new Marshaller[BigDecimal] {
+      override def stream(value: BigDecimal): InputStream =
+        new ByteArrayInputStream(BigDecimalUtil.bigDecimalToByte(value))
+
+      override def parse(stream: InputStream): BigDecimal =
+        BigDecimalUtil.byteToBigDecimal(ByteStreams.toByteArray(stream))
+    }
+
+  }
+
+  object pbd extends Marshallers {
 
     import pbdirect._
 
@@ -38,7 +53,7 @@ object encoders {
       }
   }
 
-  object avro {
+  object avro extends Marshallers {
 
     import com.sksamuel.avro4s._
 
@@ -70,7 +85,7 @@ object encoders {
       }
   }
 
-  object avrowithschema {
+  object avrowithschema extends Marshallers {
 
     import com.sksamuel.avro4s._
     import org.apache.avro.file.DataFileStream

--- a/modules/internal/src/main/scala/util/BigDecimalUtil.scala
+++ b/modules/internal/src/main/scala/util/BigDecimalUtil.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc
+package internal
+package util
+
+object BigDecimalUtil {
+
+  def bigDecimalToByte(num: BigDecimal): Array[Byte] = {
+    val sig: Array[Byte] = num.bigDecimal.unscaledValue().toByteArray
+    val scale: Int       = num.scale
+    val byteScale: Array[Byte] =
+      Array[Byte]((scale >>> 24).toByte, (scale >>> 16).toByte, (scale >>> 8).toByte, scale.toByte)
+    byteScale ++ sig
+  }
+
+  def byteToBigDecimal(raw: Array[Byte]): BigDecimal = {
+    val scale = (raw(0) & 0xFF) << 24 | (raw(1) & 0xFF) << 16 | (raw(2) & 0xFF) << 8 | (raw(3) & 0xFF)
+    val sig   = new java.math.BigInteger(raw.drop(4))
+    BigDecimal(sig, scale)
+  }
+
+}

--- a/modules/internal/src/test/scala/util/BigDecimalUtilTest.scala
+++ b/modules/internal/src/test/scala/util/BigDecimalUtilTest.scala
@@ -41,6 +41,16 @@ class BigDecimalUtilTest extends WordSpec with Matchers with Checkers {
 
   "BigDecimalUtil" should {
 
+    "allow to convert BigDecimals for and from byte arrays" in {
+      check {
+        forAll { bd: BigDecimal =>
+          val array = BigDecimalUtil.bigDecimalToByte(bd)
+          BigDecimalUtil.byteToBigDecimal(array) shouldBe bd
+          BigDecimalUtil.byteToBigDecimal(array) == bd
+        }
+      }
+    }
+
     "allow to convert BigDecimals created from doubles for and from byte arrays" in {
       checkAll[Double](BigDecimal.decimal)
     }

--- a/modules/internal/src/test/scala/util/BigDecimalUtilTest.scala
+++ b/modules/internal/src/test/scala/util/BigDecimalUtilTest.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc
+package internal
+package util
+
+import org.scalacheck.Gen.Choose
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest._
+import org.scalacheck.Prop._
+import org.scalatest.prop.Checkers
+
+class BigDecimalUtilTest extends WordSpec with Matchers with Checkers {
+
+  def checkAll[T](f: T => BigDecimal)(implicit N: Numeric[T], C: Choose[T]): Assertion = {
+    implicit val bigDecimalArbitrary: Arbitrary[BigDecimal] =
+      Arbitrary(Gen.posNum[T].map(f))
+
+    check {
+      forAll { bd: BigDecimal =>
+        val array = BigDecimalUtil.bigDecimalToByte(bd)
+        BigDecimalUtil.byteToBigDecimal(array) shouldBe bd
+        BigDecimalUtil.byteToBigDecimal(array) == bd
+      }
+    }
+  }
+
+  "BigDecimalUtil" should {
+
+    "allow to convert BigDecimals created from doubles for and from byte arrays" in {
+      checkAll[Double](BigDecimal.decimal)
+    }
+
+    "allow to convert BigDecimals created from floats for and from byte arrays" in {
+      checkAll[Float](BigDecimal.decimal)
+    }
+
+    "allow to convert BigDecimals created from longs for and from byte arrays" in {
+      checkAll[Long](BigDecimal.decimal)
+    }
+  }
+
+}

--- a/modules/server/src/test/scala/protocol/RPCTests.scala
+++ b/modules/server/src/test/scala/protocol/RPCTests.scala
@@ -241,6 +241,39 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
       clientProgram[ConcurrentMonad].unsafeRunSync() shouldBe 3000
     }
 
+    "BigDecimal param with Proto" in {
+
+      val bd: BigDecimal = BigDecimal(scala.util.Random.nextDouble())
+
+      def clientProgram[F[_]: cats.Functor](
+          implicit client: service.RPCService.Client[F]): F[BigDecimal] =
+        client.bigDecimalParamResponse(bd)
+
+      clientProgram[ConcurrentMonad].unsafeRunSync() shouldBe bd
+    }
+
+    "BigDecimal param with Avro" in {
+
+      val bd: BigDecimal = BigDecimal(scala.util.Random.nextDouble())
+
+      def clientProgram[F[_]: cats.Functor](
+          implicit client: service.RPCService.Client[F]): F[BigDecimal] =
+        client.bigDecimalAvroParam(bd)
+
+      clientProgram[ConcurrentMonad].unsafeRunSync() shouldBe bd
+    }
+
+    "BigDecimal param with AvroWithSchema" in {
+
+      val bd: BigDecimal = BigDecimal(scala.util.Random.nextDouble())
+
+      def clientProgram[F[_]: cats.Functor](
+          implicit client: service.RPCService.Client[F]): F[BigDecimal] =
+        client.bigDecimalAvroWithSchemaParam(bd)
+
+      clientProgram[ConcurrentMonad].unsafeRunSync() shouldBe bd
+    }
+
   }
 
   "frees-rpc client with compression" should {

--- a/modules/server/src/test/scala/protocol/Utils.scala
+++ b/modules/server/src/test/scala/protocol/Utils.scala
@@ -58,6 +58,8 @@ object Utils extends CommonUtils {
 
       @rpc(Protobuf, Gzip) def emptyParamResponseCompressed(empty: Empty.type): F[A]
 
+      @rpc(Protobuf) def bigDecimalParamResponse(bd: BigDecimal): F[BigDecimal]
+
       @rpc(Avro) def emptyAvro(empty: Empty.type): F[Empty.type]
 
       @rpc(AvroWithSchema) def emptyAvroWithSchema(empty: Empty.type): F[Empty.type]
@@ -82,6 +84,10 @@ object Utils extends CommonUtils {
 
       @rpc(AvroWithSchema, Gzip) def emptyAvroWithSchemaParamResponseCompressed(
           empty: Empty.type): F[A]
+
+      @rpc(Avro) def bigDecimalAvroParam(bd: BigDecimal): F[BigDecimal]
+
+      @rpc(AvroWithSchema) def bigDecimalAvroWithSchemaParam(bd: BigDecimal): F[BigDecimal]
 
       @rpc(Protobuf)
       @stream[ResponseStreaming.type]
@@ -130,23 +136,26 @@ object Utils extends CommonUtils {
   object client {
 
     @tagless(true)
-    trait MyRPCClient {
-      def notAllowed(b: Boolean): FS[C]
-      def empty: FS[Empty.type]
-      def emptyParam(a: A): FS[Empty.type]
-      def emptyParamResponse: FS[A]
-      def emptyAvro: FS[Empty.type]
-      def emptyAvroWithSchema: FS[Empty.type]
-      def emptyAvroParam(a: A): FS[Empty.type]
-      def emptyAvroWithSchemaParam(a: A): FS[Empty.type]
-      def emptyAvroParamResponse: FS[A]
-      def emptyAvroWithSchemaParamResponse: FS[A]
-      def u(x: Int, y: Int): FS[C]
-      def uws(x: Int, y: Int): FS[C]
-      def ss(a: Int, b: Int): FS[List[C]]
-      def cs(cList: List[C], bar: Int): FS[D]
-      def bs(eList: List[E]): FS[E]
-      def bsws(eList: List[E]): FS[E]
+    trait MyRPCClient[F[_]] {
+      def notAllowed(b: Boolean): F[C]
+      def empty: F[Empty.type]
+      def emptyParam(a: A): F[Empty.type]
+      def emptyParamResponse: F[A]
+      def bigDecimalParamResponse(bd: BigDecimal): F[BigDecimal]
+      def emptyAvro: F[Empty.type]
+      def emptyAvroWithSchema: F[Empty.type]
+      def emptyAvroParam(a: A): F[Empty.type]
+      def emptyAvroWithSchemaParam(a: A): F[Empty.type]
+      def emptyAvroParamResponse: F[A]
+      def emptyAvroWithSchemaParamResponse: F[A]
+      def bigDecimalAvroParam(bd: BigDecimal): F[BigDecimal]
+      def bigDecimalAvroWithSchemaParam(bd: BigDecimal): F[BigDecimal]
+      def u(x: Int, y: Int): F[C]
+      def uws(x: Int, y: Int): F[C]
+      def ss(a: Int, b: Int): F[List[C]]
+      def cs(cList: List[C], bar: Int): F[D]
+      def bs(eList: List[E]): F[E]
+      def bsws(eList: List[E]): F[E]
     }
 
   }
@@ -168,6 +177,8 @@ object Utils extends CommonUtils {
         def emptyParam(a: A): F[Empty.type] = Empty.pure
 
         def emptyParamResponse(empty: Empty.type): F[A] = a4.pure
+
+        def bigDecimalParamResponse(bd: BigDecimal): F[BigDecimal] = bd.pure
 
         def emptyAvro(empty: Empty.type): F[Empty.type] = Empty.pure
 
@@ -233,6 +244,10 @@ object Utils extends CommonUtils {
         def emptyAvroWithSchemaParamResponseCompressed(empty: Empty.type): F[A] =
           emptyAvroParamResponseCompressed(empty)
 
+        def bigDecimalAvroParam(bd: BigDecimal): F[BigDecimal] = bd.pure
+
+        def bigDecimalAvroWithSchemaParam(bd: BigDecimal): F[BigDecimal] = bd.pure
+
         def unaryCompressed(a: A): F[C] = unary(a)
 
         def unaryCompressedWithSchema(a: A): F[C] = unaryCompressed(a)
@@ -278,6 +293,9 @@ object Utils extends CommonUtils {
         override def emptyParamResponse: F[A] =
           client.emptyParamResponse(protocol.Empty)
 
+        override def bigDecimalParamResponse(bd: BigDecimal): F[BigDecimal] =
+          client.bigDecimalParamResponse(bd)
+
         override def emptyAvro: F[Empty.type] =
           client.emptyAvro(protocol.Empty)
 
@@ -295,6 +313,12 @@ object Utils extends CommonUtils {
 
         override def emptyAvroWithSchemaParamResponse: F[A] =
           client.emptyAvroWithSchemaParamResponse(protocol.Empty)
+
+        override def bigDecimalAvroParam(bd: BigDecimal): F[BigDecimal] =
+          client.bigDecimalAvroParam(bd)
+
+        override def bigDecimalAvroWithSchemaParam(bd: BigDecimal): F[BigDecimal] =
+          client.bigDecimalAvroWithSchemaParam(bd)
 
         override def u(x: Int, y: Int): F[C] =
           client.unary(A(x, y))
@@ -363,6 +387,9 @@ object Utils extends CommonUtils {
         override def emptyParamResponse: F[A] =
           client.emptyParamResponseCompressed(protocol.Empty)
 
+        override def bigDecimalParamResponse(bd: BigDecimal): F[BigDecimal] =
+          client.bigDecimalParamResponse(bd)
+
         override def emptyAvro: F[Empty.type] =
           client.emptyAvroCompressed(protocol.Empty)
 
@@ -380,6 +407,12 @@ object Utils extends CommonUtils {
 
         override def emptyAvroWithSchemaParamResponse: F[A] =
           client.emptyAvroWithSchemaParamResponseCompressed(protocol.Empty)
+
+        override def bigDecimalAvroParam(bd: BigDecimal): F[BigDecimal] =
+          client.bigDecimalAvroParam(bd)
+
+        override def bigDecimalAvroWithSchemaParam(bd: BigDecimal): F[BigDecimal] =
+          client.bigDecimalAvroWithSchemaParam(bd)
 
         override def u(x: Int, y: Int): F[C] =
           client.unaryCompressed(A(x, y))


### PR DESCRIPTION
Fixes #239 by providing serializers for `scala.math.BigDecimal`