### PR TITLE
Allows generating code from IDL in jars and submodules

### DIFF
--- a/modules/idlgen/plugin/src/main/scala/IdlGenPlugin.scala
+++ b/modules/idlgen/plugin/src/main/scala/IdlGenPlugin.scala
@@ -20,6 +20,7 @@ import java.io.File
 
 import sbt.Keys._
 import sbt._
+import sbt.io.{Path, PathFinder}
 
 object IdlGenPlugin extends AutoPlugin {
 
@@ -39,6 +40,10 @@ object IdlGenPlugin extends AutoPlugin {
     lazy val idlType: SettingKey[String] =
       settingKey[String]("The IDL type to work with, such as avro or proto")
 
+    lazy val idlExtension: SettingKey[String] =
+      settingKey[String](
+        "The IDL extension to work with, files with a different extension will be omitted. By default 'avdl' for avro and 'proto' for proto")
+
     lazy val srcGenSerializationType: SettingKey[String] =
       settingKey[String](
         "The serialization type when generating Scala sources from the IDL definitions." +
@@ -55,8 +60,7 @@ object IdlGenPlugin extends AutoPlugin {
           "in subdirectories such as `proto` for Protobuf and `avro` for Avro, based on freestyle-rpc service definitions.")
 
     lazy val srcGenSourceFromJarsDir: SettingKey[File] =
-      settingKey[File](
-        "The list of directories where your IDL files are placed")
+      settingKey[File]("The list of directories where your IDL files are placed")
 
     @deprecated("This settings is deprecated in favor of srcGenSourceDirs", "0.14.0")
     lazy val srcGenSourceDir: SettingKey[File] =
@@ -84,6 +88,9 @@ object IdlGenPlugin extends AutoPlugin {
 
   lazy val defaultSettings: Seq[Def.Setting[_]] = Seq(
     idlType := "(missing arg)",
+    idlExtension := (if (idlType.value == "avro") "avdl"
+                     else if (idlType.value == "proto") "proto"
+                     else "unknown"),
     srcGenSerializationType := "Avro",
     idlGenSourceDir := (Compile / sourceDirectory).value,
     idlGenTargetDir := (Compile / resourceManaged).value,
@@ -113,10 +120,18 @@ object IdlGenPlugin extends AutoPlugin {
         target.value / "srcGen")(srcGenSourceDirs.value.allPaths.get.toSet).toSeq,
       srcGenFromJars := {
         Def
-          .sequential(Def.task {
-            (dependencyClasspath in Compile).value.map(entry =>
-              extractIDLDefinitionsFromJar(entry, srcJarNames.value, srcGenSourceFromJarsDir.value))
-          }, srcGen)
+          .sequential(
+            Def.task {
+              (dependencyClasspath in Compile).value.map(
+                entry =>
+                  extractIDLDefinitionsFromJar(
+                    entry,
+                    srcJarNames.value,
+                    srcGenSourceFromJarsDir.value,
+                    idlExtension.value))
+            },
+            srcGen
+          )
           .value
       }
     )
@@ -137,15 +152,29 @@ object IdlGenPlugin extends AutoPlugin {
   private def extractIDLDefinitionsFromJar(
       classpathEntry: Attributed[File],
       jarNames: Seq[String],
-      target: File): File = {
+      target: File,
+      idlExtension: String): File = {
+
+    val nameFilter: NameFilter = new NameFilter {
+      override def accept(name: String): Boolean =
+        name.toLowerCase.endsWith("." + idlExtension)
+    }
+
     classpathEntry.get(artifact.key).fold((): Unit) { entryArtifact =>
       if (jarNames.exists(entryArtifact.name.startsWith)) {
         IO.withTemporaryDirectory { tmpDir =>
-          IO.unzip(classpathEntry.data, tmpDir)
-          IO.copyDirectory(
-            tmpDir,
-            target
-          )
+          if (classpathEntry.data.isDirectory) {
+            val sources = PathFinder(classpathEntry.data).allPaths pair Path
+              .rebase(classpathEntry.data, target)
+            IO.copy(
+              sources.filter(tuple => nameFilter.accept(tuple._2)),
+              overwrite = true,
+              preserveLastModified = true,
+              preserveExecutable = true)
+          } else {
+            IO.unzip(classpathEntry.data, tmpDir, nameFilter)
+            IO.copyDirectory(tmpDir, target)
+          }
         }
       }
     }


### PR DESCRIPTION
This is the solution that I've found for generating code from IDL present in jar files and submodules and you're running an application (or generating a fat jar).

In the srcJarNames you need to specify not only the jars but also the submodule names that contain the IDL files.

Potentially, we'd need to change the setting name for something like srcIdlNames or something like that. This also filters the files copied to srcGenSourceFromJarsDir, so probably we wouldn't need the mappings in (Compile, packageBin) ~= { _.filter(!_._1.getName.endsWith(".class")) } filter anymore.

Thoughts?