### PR TITLE
Removes the IDL core Dependency

### DIFF
--- a/modules/idlgen/plugin/src/main/scala/IdlGenPlugin.scala
+++ b/modules/idlgen/plugin/src/main/scala/IdlGenPlugin.scala
@@ -207,7 +207,5 @@ object IdlGenPlugin extends AutoPlugin {
   }
 
   override def projectSettings: Seq[Def.Setting[_]] =
-    defaultSettings ++ taskSettings ++ packagingSettings ++ Seq(
-      libraryDependencies += "io.frees" %% "frees-rpc-idlgen-core" % freestyle.rpc.idlgen.BuildInfo.version
-    )
+    defaultSettings ++ taskSettings ++ packagingSettings
 }

--- a/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/srcGenFromDirs/build.sbt
+++ b/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/srcGenFromDirs/build.sbt
@@ -1,17 +1,18 @@
 lazy val root = project
   .in(file("."))
   .settings(name := "root")
-    .settings(version := "1.0.0")
-    .settings(Seq(
-      publishMavenStyle := true,
-      mappings in (Compile, packageBin) ~= { _.filter(!_._1.getName.endsWith(".class")) },
-      idlType := "avro",
-      srcGenSourceDirs := Seq((Compile / resourceDirectory).value / "domain",
-        (Compile / resourceDirectory).value / "protocol"),
-      srcGenTargetDir := (Compile / sourceManaged).value / "compiled_avro",
-      sourceGenerators in Compile += (Compile / srcGen).taskValue,
-      libraryDependencies ++= Seq(
-        "com.chuusai" %% "shapeless" % "2.3.2"
-      )
-    ))
-
+  .settings(version := "1.0.0")
+  .settings(Seq(
+    publishMavenStyle := true,
+    mappings in (Compile, packageBin) ~= { _.filter(!_._1.getName.endsWith(".class")) },
+    idlType := "avro",
+    srcGenSourceDirs := Seq(
+      (Compile / resourceDirectory).value / "domain",
+      (Compile / resourceDirectory).value / "protocol"),
+    srcGenTargetDir := (Compile / sourceManaged).value / "compiled_avro",
+    sourceGenerators in Compile += (Compile / srcGen).taskValue,
+    libraryDependencies ++= Seq(
+      "io.frees"    %% "frees-rpc-client-core" % sys.props("version"),
+      "com.chuusai" %% "shapeless"        % "2.3.2"
+    )
+  ))

--- a/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/srcGenFromJars/build.sbt
+++ b/modules/idlgen/plugin/src/sbt-test/sbt-frees-rpc-idlgen/srcGenFromJars/build.sbt
@@ -12,10 +12,11 @@ lazy val domain = project
     publishMavenStyle := true,
     mappings in (Compile, packageBin) ~= { _.filter(!_._1.getName.endsWith(".class")) },
     idlType := "avro",
-    srcGenSourceDir := (Compile / resourceDirectory).value,
+    srcGenSourceDirs := Seq((Compile / resourceDirectory).value),
     srcGenTargetDir := (Compile / sourceManaged).value / "compiled_avro",
     sourceGenerators in Compile += (Compile / srcGen).taskValue,
     libraryDependencies ++= Seq(
+      "io.frees"    %% "frees-rpc-client-core" % sys.props("version"),
       "com.chuusai" %% "shapeless" % "2.3.2"
     )
   ))


### PR DESCRIPTION
... from the `ProjectPlugin` which it seems to not be needed.