### PR TITLE
BigDecimal serialization in protobuf and avro

### DIFF
--- a/modules/internal/src/test/scala/util/BigDecimalUtilTest.scala
+++ b/modules/internal/src/test/scala/util/BigDecimalUtilTest.scala
@@ -30,36 +30,36 @@ class BigDecimalUtilTest extends WordSpec with Matchers with Checkers {
     implicit val bigDecimalArbitrary: Arbitrary[BigDecimal] =
       Arbitrary(Gen.posNum[T].map(f))
 
-    check {
+    check(
       forAll { bd: BigDecimal =>
         val array = BigDecimalUtil.bigDecimalToByte(bd)
-        BigDecimalUtil.byteToBigDecimal(array) shouldBe bd
         BigDecimalUtil.byteToBigDecimal(array) == bd
-      }
-    }
+      },
+      MinSuccessful(1000)
+    )
   }
 
   "BigDecimalUtil" should {
 
-    "allow to convert BigDecimals for and from byte arrays" in {
-      check {
+    "allow to convert BigDecimals to and from byte arrays" in {
+      check(
         forAll { bd: BigDecimal =>
           val array = BigDecimalUtil.bigDecimalToByte(bd)
-          BigDecimalUtil.byteToBigDecimal(array) shouldBe bd
           BigDecimalUtil.byteToBigDecimal(array) == bd
-        }
-      }
+        },
+        MinSuccessful(1000)
+      )
     }
 
-    "allow to convert BigDecimals created from doubles for and from byte arrays" in {
+    "allow to convert BigDecimals created from doubles to and from byte arrays" in {
       checkAll[Double](BigDecimal.decimal)
     }
 
-    "allow to convert BigDecimals created from floats for and from byte arrays" in {
+    "allow to convert BigDecimals created from floats to and from byte arrays" in {
       checkAll[Float](BigDecimal.decimal)
     }
 
-    "allow to convert BigDecimals created from longs for and from byte arrays" in {
+    "allow to convert BigDecimals created from longs to and from byte arrays" in {
       checkAll[Long](BigDecimal.decimal)
     }
   }

--- a/modules/server/src/test/scala/protocol/RPCBigDecimalTests.scala
+++ b/modules/server/src/test/scala/protocol/RPCBigDecimalTests.scala
@@ -18,6 +18,7 @@ package freestyle.rpc
 package protocol
 
 import cats.Applicative
+import cats.syntax.applicative._
 import org.scalatest._
 import freestyle.rpc.common._
 import freestyle.rpc.testing.servers.withServerChannel
@@ -46,22 +47,22 @@ class RPCBigDecimalTests extends RpcBaseTestSuite with BeforeAndAfterAll with Ch
 
     }
 
-    class RPCServiceDefImpl[F[_]](implicit A: Applicative[F]) extends RPCServiceDef[F] {
+    class RPCServiceDefImpl[F[_]: Applicative] extends RPCServiceDef[F] {
 
-      def bigDecimalProto(bd: BigDecimal): F[BigDecimal] = A.pure(bd)
+      def bigDecimalProto(bd: BigDecimal): F[BigDecimal] = bd.pure
 
       def bigDecimalProtoWrapper(req: Request): F[Response] =
-        A.pure(Response(req.bigDecimal, req.label, check = true))
+        Response(req.bigDecimal, req.label, check = true).pure
 
-      def bigDecimalAvro(bd: BigDecimal): F[BigDecimal] = A.pure(bd)
+      def bigDecimalAvro(bd: BigDecimal): F[BigDecimal] = bd.pure
 
       def bigDecimalAvroWrapper(req: Request): F[Response] =
-        A.pure(Response(req.bigDecimal, req.label, check = true))
+        Response(req.bigDecimal, req.label, check = true).pure
 
-      def bigDecimalAvroWithSchema(bd: BigDecimal): F[BigDecimal] = A.pure(bd)
+      def bigDecimalAvroWithSchema(bd: BigDecimal): F[BigDecimal] = bd.pure
 
       def bigDecimalAvroWithSchemaWrapper(req: Request): F[Response] =
-        A.pure(Response(req.bigDecimal, req.label, check = true))
+        Response(req.bigDecimal, req.label, check = true).pure
     }
 
   }

--- a/modules/server/src/test/scala/protocol/RPCBigDecimalTests.scala
+++ b/modules/server/src/test/scala/protocol/RPCBigDecimalTests.scala
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc
+package protocol
+
+import cats.Applicative
+import org.scalatest._
+import freestyle.rpc.common._
+import freestyle.rpc.testing.servers.withServerChannel
+import org.scalacheck.Prop._
+import org.scalatest.prop.Checkers
+
+class RPCBigDecimalTests extends RpcBaseTestSuite with BeforeAndAfterAll with Checkers {
+
+  object RPCService {
+
+    case class Request(bigDecimal: BigDecimal, label: String)
+
+    case class Response(bigDecimal: BigDecimal, result: String, check: Boolean)
+
+    @service
+    trait RPCServiceDef[F[_]] {
+
+      @rpc(Protobuf) def bigDecimalProto(bd: BigDecimal): F[BigDecimal]
+      @rpc(Protobuf) def bigDecimalProtoWrapper(req: Request): F[Response]
+
+      @rpc(Avro) def bigDecimalAvro(bd: BigDecimal): F[BigDecimal]
+      @rpc(Avro) def bigDecimalAvroWrapper(req: Request): F[Response]
+
+      @rpc(AvroWithSchema) def bigDecimalAvroWithSchema(bd: BigDecimal): F[BigDecimal]
+      @rpc(AvroWithSchema) def bigDecimalAvroWithSchemaWrapper(req: Request): F[Response]
+
+    }
+
+    class RPCServiceDefImpl[F[_]](implicit A: Applicative[F]) extends RPCServiceDef[F] {
+
+      def bigDecimalProto(bd: BigDecimal): F[BigDecimal] = A.pure(bd)
+
+      def bigDecimalProtoWrapper(req: Request): F[Response] =
+        A.pure(Response(req.bigDecimal, req.label, check = true))
+
+      def bigDecimalAvro(bd: BigDecimal): F[BigDecimal] = A.pure(bd)
+
+      def bigDecimalAvroWrapper(req: Request): F[Response] =
+        A.pure(Response(req.bigDecimal, req.label, check = true))
+
+      def bigDecimalAvroWithSchema(bd: BigDecimal): F[BigDecimal] = A.pure(bd)
+
+      def bigDecimalAvroWithSchemaWrapper(req: Request): F[Response] =
+        A.pure(Response(req.bigDecimal, req.label, check = true))
+    }
+
+  }
+
+  "A RPC server" should {
+
+    import RPCService._
+    import monix.execution.Scheduler.Implicits.global
+
+    implicit val H: RPCServiceDef[ConcurrentMonad] = new RPCServiceDefImpl[ConcurrentMonad]
+
+    "be able to serialize and deserialize BigDecimal using proto format" in {
+
+      withServerChannel(RPCServiceDef.bindService[ConcurrentMonad]) { sc =>
+        val client: RPCServiceDef.Client[ConcurrentMonad] =
+          RPCServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+
+        check {
+          forAll { bd: BigDecimal =>
+            client.bigDecimalProto(bd).unsafeRunSync() == bd
+          }
+        }
+
+      }
+
+    }
+
+    "be able to serialize and deserialize BigDecimal in a Request using proto format" in {
+
+      withServerChannel(RPCServiceDef.bindService[ConcurrentMonad]) { sc =>
+        val client: RPCServiceDef.Client[ConcurrentMonad] =
+          RPCServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+
+        check {
+          forAll { (bd: BigDecimal, s: String) =>
+            client.bigDecimalProtoWrapper(Request(bd, s)).unsafeRunSync() == Response(
+              bd,
+              s,
+              check = true)
+          }
+        }
+
+      }
+
+    }
+
+    "be able to serialize and deserialize BigDecimal using avro format" in {
+
+      withServerChannel(RPCServiceDef.bindService[ConcurrentMonad]) { sc =>
+        val client: RPCServiceDef.Client[ConcurrentMonad] =
+          RPCServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+
+        check {
+          forAll { bd: BigDecimal =>
+            client.bigDecimalAvro(bd).unsafeRunSync() == bd
+          }
+        }
+
+      }
+
+    }
+
+    "be able to serialize and deserialize BigDecimal in a Request using avro format" in {
+
+      withServerChannel(RPCServiceDef.bindService[ConcurrentMonad]) { sc =>
+        val client: RPCServiceDef.Client[ConcurrentMonad] =
+          RPCServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+
+        check {
+          forAll { (bd: BigDecimal, s: String) =>
+            client.bigDecimalAvroWrapper(Request(bd, s)).unsafeRunSync() == Response(
+              bd,
+              s,
+              check = true)
+          }
+        }
+
+      }
+
+    }
+
+    "be able to serialize and deserialize BigDecimal using avro with schema format" in {
+
+      withServerChannel(RPCServiceDef.bindService[ConcurrentMonad]) { sc =>
+        val client: RPCServiceDef.Client[ConcurrentMonad] =
+          RPCServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+
+        check {
+          forAll { bd: BigDecimal =>
+            client.bigDecimalAvroWithSchema(bd).unsafeRunSync() == bd
+          }
+        }
+
+      }
+
+    }
+
+    "be able to serialize and deserialize BigDecimal in a Request using avro with schema format" in {
+
+      withServerChannel(RPCServiceDef.bindService[ConcurrentMonad]) { sc =>
+        val client: RPCServiceDef.Client[ConcurrentMonad] =
+          RPCServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+
+        check {
+          forAll { (bd: BigDecimal, s: String) =>
+            client.bigDecimalAvroWithSchemaWrapper(Request(bd, s)).unsafeRunSync() == Response(
+              bd,
+              s,
+              check = true)
+          }
+        }
+
+      }
+
+    }
+
+  }
+
+}

--- a/modules/server/src/test/scala/protocol/RPCTests.scala
+++ b/modules/server/src/test/scala/protocol/RPCTests.scala
@@ -271,39 +271,6 @@ class RPCTests extends RpcBaseTestSuite with BeforeAndAfterAll {
       clientProgram[ConcurrentMonad].unsafeRunSync() shouldBe 3000
     }
 
-    "BigDecimal param with Proto" in {
-
-      val bd: BigDecimal = BigDecimal(scala.util.Random.nextDouble())
-
-      def clientProgram[F[_]: cats.Functor](
-          implicit client: service.RPCService.Client[F]): F[BigDecimal] =
-        client.bigDecimalParamResponse(bd)
-
-      clientProgram[ConcurrentMonad].unsafeRunSync() shouldBe bd
-    }
-
-    "BigDecimal param with Avro" in {
-
-      val bd: BigDecimal = BigDecimal(scala.util.Random.nextDouble())
-
-      def clientProgram[F[_]: cats.Functor](
-          implicit client: service.RPCService.Client[F]): F[BigDecimal] =
-        client.bigDecimalAvroParam(bd)
-
-      clientProgram[ConcurrentMonad].unsafeRunSync() shouldBe bd
-    }
-
-    "BigDecimal param with AvroWithSchema" in {
-
-      val bd: BigDecimal = BigDecimal(scala.util.Random.nextDouble())
-
-      def clientProgram[F[_]: cats.Functor](
-          implicit client: service.RPCService.Client[F]): F[BigDecimal] =
-        client.bigDecimalAvroWithSchemaParam(bd)
-
-      clientProgram[ConcurrentMonad].unsafeRunSync() shouldBe bd
-    }
-
   }
 
   "frees-rpc client with compression" should {

--- a/modules/server/src/test/scala/protocol/Utils.scala
+++ b/modules/server/src/test/scala/protocol/Utils.scala
@@ -63,8 +63,6 @@ object Utils extends CommonUtils {
 
       @rpc(Protobuf, Gzip) def emptyParamResponseCompressed(empty: Empty.type): F[A]
 
-      @rpc(Protobuf) def bigDecimalParamResponse(bd: BigDecimal): F[BigDecimal]
-
       @rpc(Avro) def emptyAvro(empty: Empty.type): F[Empty.type]
 
       @rpc(AvroWithSchema) def emptyAvroWithSchema(empty: Empty.type): F[Empty.type]
@@ -89,10 +87,6 @@ object Utils extends CommonUtils {
 
       @rpc(AvroWithSchema, Gzip) def emptyAvroWithSchemaParamResponseCompressed(
           empty: Empty.type): F[A]
-
-      @rpc(Avro) def bigDecimalAvroParam(bd: BigDecimal): F[BigDecimal]
-
-      @rpc(AvroWithSchema) def bigDecimalAvroWithSchemaParam(bd: BigDecimal): F[BigDecimal]
 
       @rpc(Protobuf)
       @stream[ResponseStreaming.type]
@@ -154,15 +148,12 @@ object Utils extends CommonUtils {
       def empty: F[Empty.type]
       def emptyParam(a: A): F[Empty.type]
       def emptyParamResponse: F[A]
-      def bigDecimalParamResponse(bd: BigDecimal): F[BigDecimal]
       def emptyAvro: F[Empty.type]
       def emptyAvroWithSchema: F[Empty.type]
       def emptyAvroParam(a: A): F[Empty.type]
       def emptyAvroWithSchemaParam(a: A): F[Empty.type]
       def emptyAvroParamResponse: F[A]
       def emptyAvroWithSchemaParamResponse: F[A]
-      def bigDecimalAvroParam(bd: BigDecimal): F[BigDecimal]
-      def bigDecimalAvroWithSchemaParam(bd: BigDecimal): F[BigDecimal]
       def u(x: Int, y: Int): F[C]
       def uws(x: Int, y: Int): F[C]
       def uwe(a: A, err: String): F[C]
@@ -194,8 +185,6 @@ object Utils extends CommonUtils {
         def emptyParam(a: A): F[Empty.type] = Empty.pure
 
         def emptyParamResponse(empty: Empty.type): F[A] = a4.pure
-
-        def bigDecimalParamResponse(bd: BigDecimal): F[BigDecimal] = bd.pure
 
         def emptyAvro(empty: Empty.type): F[Empty.type] = Empty.pure
 
@@ -283,10 +272,6 @@ object Utils extends CommonUtils {
         def emptyAvroWithSchemaParamResponseCompressed(empty: Empty.type): F[A] =
           emptyAvroParamResponseCompressed(empty)
 
-        def bigDecimalAvroParam(bd: BigDecimal): F[BigDecimal] = bd.pure
-
-        def bigDecimalAvroWithSchemaParam(bd: BigDecimal): F[BigDecimal] = bd.pure
-
         def unaryCompressed(a: A): F[C] = unary(a)
 
         def unaryCompressedWithSchema(a: A): F[C] = unaryCompressed(a)
@@ -336,9 +321,6 @@ object Utils extends CommonUtils {
         override def emptyParamResponse: F[A] =
           client.emptyParamResponse(protocol.Empty)
 
-        override def bigDecimalParamResponse(bd: BigDecimal): F[BigDecimal] =
-          client.bigDecimalParamResponse(bd)
-
         override def emptyAvro: F[Empty.type] =
           client.emptyAvro(protocol.Empty)
 
@@ -356,12 +338,6 @@ object Utils extends CommonUtils {
 
         override def emptyAvroWithSchemaParamResponse: F[A] =
           client.emptyAvroWithSchemaParamResponse(protocol.Empty)
-
-        override def bigDecimalAvroParam(bd: BigDecimal): F[BigDecimal] =
-          client.bigDecimalAvroParam(bd)
-
-        override def bigDecimalAvroWithSchemaParam(bd: BigDecimal): F[BigDecimal] =
-          client.bigDecimalAvroWithSchemaParam(bd)
 
         override def u(x: Int, y: Int): F[C] =
           client.unary(A(x, y))
@@ -451,9 +427,6 @@ object Utils extends CommonUtils {
         override def emptyParamResponse: F[A] =
           client.emptyParamResponseCompressed(protocol.Empty)
 
-        override def bigDecimalParamResponse(bd: BigDecimal): F[BigDecimal] =
-          client.bigDecimalParamResponse(bd)
-
         override def emptyAvro: F[Empty.type] =
           client.emptyAvroCompressed(protocol.Empty)
 
@@ -471,12 +444,6 @@ object Utils extends CommonUtils {
 
         override def emptyAvroWithSchemaParamResponse: F[A] =
           client.emptyAvroWithSchemaParamResponseCompressed(protocol.Empty)
-
-        override def bigDecimalAvroParam(bd: BigDecimal): F[BigDecimal] =
-          client.bigDecimalAvroParam(bd)
-
-        override def bigDecimalAvroWithSchemaParam(bd: BigDecimal): F[BigDecimal] =
-          client.bigDecimalAvroWithSchemaParam(bd)
 
         override def u(x: Int, y: Int): F[C] =
           client.unaryCompressed(A(x, y))


### PR DESCRIPTION
Provides `BigDecimal` serialization in protobuf and avro.

In the case of avro, I've created the `SchemaFor`, `FromValue`, and `ToValue` instances that will be used in the shapeless derivation of case classes in avro4s. 

Also, a `Marshaller` is provided in avro for serializing `BigDecimal`s as requests and/or responses because Avro doesn't provide the automatic derivation of `FromRecord` and `ToRecord` instances for other types than products.