### PR TITLE
Adds a java time util for serializing dates

### DIFF
--- a/modules/internal/src/main/scala/util/JavaTimeUtil.scala
+++ b/modules/internal/src/main/scala/util/JavaTimeUtil.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc
+package internal
+package util
+
+import java.time._
+
+object JavaTimeUtil {
+
+  def localDateToInt(value: LocalDate): Int = value.toEpochDay.toInt
+
+  def intToLocalDate(value: Int): LocalDate = LocalDate.ofEpochDay(value.toLong)
+
+  def localDateTimeToLong(value: LocalDateTime): Long =
+    value.toInstant(ZoneOffset.UTC).toEpochMilli
+
+  def longToLocalDateTime(value: Long): LocalDateTime =
+    ZonedDateTime.ofInstant(Instant.ofEpochMilli(value), ZoneOffset.UTC).toLocalDateTime
+}

--- a/modules/internal/src/test/scala/util/BigDecimalUtilTests.scala
+++ b/modules/internal/src/test/scala/util/BigDecimalUtilTests.scala
@@ -24,7 +24,7 @@ import org.scalatest._
 import org.scalacheck.Prop._
 import org.scalatest.prop.Checkers
 
-class BigDecimalUtilTest extends WordSpec with Matchers with Checkers {
+class BigDecimalUtilTests extends WordSpec with Matchers with Checkers {
 
   def checkAll[T](f: T => BigDecimal)(implicit N: Numeric[T], C: Choose[T]): Assertion = {
     implicit val bigDecimalArbitrary: Arbitrary[BigDecimal] =

--- a/modules/internal/src/test/scala/util/JavaTimeUtilTest.scala
+++ b/modules/internal/src/test/scala/util/JavaTimeUtilTest.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc
+package internal
+package util
+
+import java.time.{Duration, ZoneOffset, ZonedDateTime}
+
+import com.fortysevendeg.scalacheck.datetime.instances.jdk8._
+import com.fortysevendeg.scalacheck.datetime.GenDateTime._
+import org.scalatest._
+import org.scalacheck.Prop._
+import org.scalatest.prop.Checkers
+
+class JavaTimeUtilTest extends WordSpec with Matchers with Checkers {
+
+  val from: ZonedDateTime = ZonedDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)
+  val range: Duration     = Duration.ofDays(365 * 200)
+
+  "JavaTimeUtil" should {
+
+    "allow to convert LocalDate to and from int" in {
+      import com.fortysevendeg.scalacheck.datetime.jdk8.granularity.days
+      check {
+        forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
+          val date  = zdt.toLocalDate
+          val value = JavaTimeUtil.localDateToInt(date)
+          JavaTimeUtil.intToLocalDate(value) == date
+        }
+      }
+    }
+
+    "allow to convert LocalDateTime to and from long" in {
+      import com.fortysevendeg.scalacheck.datetime.jdk8.granularity.seconds
+      check {
+        forAll(genDateTimeWithinRange(from, range)) { zdt: ZonedDateTime =>
+          val date  = zdt.toLocalDateTime
+          val value = JavaTimeUtil.localDateTimeToLong(date)
+          JavaTimeUtil.longToLocalDateTime(value) == date
+        }
+      }
+    }
+  }
+
+}

--- a/modules/internal/src/test/scala/util/JavaTimeUtilTests.scala
+++ b/modules/internal/src/test/scala/util/JavaTimeUtilTests.scala
@@ -26,7 +26,7 @@ import org.scalatest._
 import org.scalacheck.Prop._
 import org.scalatest.prop.Checkers
 
-class JavaTimeUtilTest extends WordSpec with Matchers with Checkers {
+class JavaTimeUtilTests extends WordSpec with Matchers with Checkers {
 
   val from: ZonedDateTime = ZonedDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)
   val range: Duration     = Duration.ofDays(365 * 200)

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -43,7 +43,8 @@ object ProjectPlugin extends AutoPlugin {
         "-language:higherKinds"),
       libraryDependencies ++= Seq(
         %%("cats-effect", V.catsEffect) % Test,
-        %%("scalamockScalatest")        % Test
+        %%("scalamockScalatest")        % Test,
+        %%("scheckToolboxDatetime")     % Test
       )
     )
 


### PR DESCRIPTION
Adds a serializer for `LocalDate` and `LocalDateTime` more aligned with the `avro` docs:
* `LocalDate` <-> `Int`
* `LocalDateTime` <-> `Long`