### PR TITLE
Bump avrohugger to 1.0.0-RC9

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,0 +1,7 @@
+-J-Xmx5g
+-J-XX:+CMSClassUnloadingEnabled
+-J-XX:MaxMetaspaceSize=1g
+-J-XX:+HeapDumpOnOutOfMemoryError
+-Djava.awt.headless=true
+-Dfile.encoding=utf8
+-Duser.timezone=UTC

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -20,7 +20,7 @@ object ProjectPlugin extends AutoPlugin {
 
     lazy val V = new {
       val avro4s: String             = "1.8.3"
-      val avrohugger: String         = "1.0.0-RC4"
+      val avrohugger: String         = "1.0.0-RC9"
       val catsEffect: String         = "0.10.1"
       val circe: String              = "0.9.3"
       val frees: String              = "0.8.0"


### PR DESCRIPTION
Updating to this version includes support for `decimal` logical type in avro using `BigDecimal`.