### PR TITLE
Update avro4s and avrohugger

### DIFF
--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -19,8 +19,8 @@ object ProjectPlugin extends AutoPlugin {
   object autoImport {
 
     lazy val V = new {
-      val avrohugger: String         = "1.0.0-RC9"
       val avro4s: String             = "1.9.0"
+      val avrohugger: String         = "1.0.0-RC10"
       val catsEffect: String         = "0.10.1"
       val circe: String              = "0.9.3"
       val frees: String              = "0.8.0"

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -19,8 +19,8 @@ object ProjectPlugin extends AutoPlugin {
   object autoImport {
 
     lazy val V = new {
-      val avro4s: String             = "1.8.3"
       val avrohugger: String         = "1.0.0-RC9"
+      val avro4s: String             = "1.9.0"
       val catsEffect: String         = "0.10.1"
       val circe: String              = "0.9.3"
       val frees: String              = "0.8.0"


### PR DESCRIPTION
This PR updates:
- `avro4s` to `1.9.0`
- `avrohugger` to `1.0.0-RC10`

These updates include fixes for `decimal` logical type with default values and support for `date` logical type.