### PR TITLE
replace all occurrences of @tagless annotation with the manual impl

### DIFF
--- a/modules/examples/routeguide/client/src/main/scala/ClientProgram.scala
+++ b/modules/examples/routeguide/client/src/main/scala/ClientProgram.scala
@@ -19,7 +19,6 @@ package example.routeguide.client
 import cats.Monad
 import cats.syntax.flatMap._
 import cats.syntax.functor._
-import freestyle.tagless._
 import example.routeguide.protocol.Protocols._
 import example.routeguide.common.Utils
 
@@ -28,10 +27,6 @@ trait RouteGuideClient[F[_]] {
   def listFeatures(lowLat: Int, lowLon: Int, hiLat: Int, hiLon: Int): F[Unit]
   def recordRoute(features: List[Feature], numPoints: Int): F[Unit]
   def routeChat: F[Unit]
-}
-
-object RouteGuideClient {
-  trait Handler[G[_]] extends RouteGuideClient[G]
 }
 
 object ClientProgram {

--- a/modules/examples/routeguide/client/src/main/scala/ClientProgram.scala
+++ b/modules/examples/routeguide/client/src/main/scala/ClientProgram.scala
@@ -23,12 +23,15 @@ import freestyle.tagless._
 import example.routeguide.protocol.Protocols._
 import example.routeguide.common.Utils
 
-@tagless(false)
 trait RouteGuideClient[F[_]] {
   def getFeature(lat: Int, lon: Int): F[Unit]
   def listFeatures(lowLat: Int, lowLon: Int, hiLat: Int, hiLon: Int): F[Unit]
   def recordRoute(features: List[Feature], numPoints: Int): F[Unit]
   def routeChat: F[Unit]
+}
+
+object RouteGuideClient {
+  trait Handler[G[_]] extends RouteGuideClient[G]
 }
 
 object ClientProgram {

--- a/modules/examples/routeguide/client/src/main/scala/handlers/RouteGuideClientHandler.scala
+++ b/modules/examples/routeguide/client/src/main/scala/handlers/RouteGuideClientHandler.scala
@@ -32,7 +32,7 @@ class RouteGuideClientHandler[F[_]: Monad](
     implicit client: RouteGuideService.Client[F],
     M: MonadError[F, Throwable],
     T2F: Task ~> F)
-    extends RouteGuideClient.Handler[F] {
+    extends RouteGuideClient[F] {
 
   val logger = getLogger
 

--- a/modules/examples/todolist/client/src/main/scala/clients/PingPongClient.scala
+++ b/modules/examples/todolist/client/src/main/scala/clients/PingPongClient.scala
@@ -17,9 +17,10 @@
 package examples.todolist.client
 package clients
 
-import freestyle.tagless.tagless
-
-@tagless(true)
 trait PingPongClient[F[_]] {
   def ping(): F[Unit]
+}
+
+object PingPongClient {
+  trait Handler[G[_]] extends PingPongClient[G]
 }

--- a/modules/examples/todolist/client/src/main/scala/clients/PingPongClient.scala
+++ b/modules/examples/todolist/client/src/main/scala/clients/PingPongClient.scala
@@ -20,7 +20,3 @@ package clients
 trait PingPongClient[F[_]] {
   def ping(): F[Unit]
 }
-
-object PingPongClient {
-  trait Handler[G[_]] extends PingPongClient[G]
-}

--- a/modules/examples/todolist/client/src/main/scala/clients/TagClient.scala
+++ b/modules/examples/todolist/client/src/main/scala/clients/TagClient.scala
@@ -18,9 +18,7 @@ package examples.todolist.client
 package clients
 
 import examples.todolist.protocol.Protocols._
-import freestyle.tagless.tagless
 
-@tagless(true)
 trait TagClient[F[_]] {
 
   def reset(): F[Int]
@@ -35,4 +33,8 @@ trait TagClient[F[_]] {
 
   def remove(id: Int): F[Int]
 
+}
+
+object TagClient {
+  trait Handler[G[_]] extends TagClient[G]
 }

--- a/modules/examples/todolist/client/src/main/scala/clients/TagClient.scala
+++ b/modules/examples/todolist/client/src/main/scala/clients/TagClient.scala
@@ -34,7 +34,3 @@ trait TagClient[F[_]] {
   def remove(id: Int): F[Int]
 
 }
-
-object TagClient {
-  trait Handler[G[_]] extends TagClient[G]
-}

--- a/modules/examples/todolist/client/src/main/scala/clients/TodoItemClient.scala
+++ b/modules/examples/todolist/client/src/main/scala/clients/TodoItemClient.scala
@@ -18,9 +18,7 @@ package examples.todolist.client
 package clients
 
 import examples.todolist.protocol.Protocols._
-import freestyle.tagless.tagless
 
-@tagless(true)
 trait TodoItemClient[F[_]] {
 
   def reset(): F[Int]
@@ -35,4 +33,8 @@ trait TodoItemClient[F[_]] {
 
   def remove(id: Int): F[Int]
 
+}
+
+object TodoItemClient {
+  trait Handler[G[_]] extends TodoItemClient[G]
 }

--- a/modules/examples/todolist/client/src/main/scala/clients/TodoItemClient.scala
+++ b/modules/examples/todolist/client/src/main/scala/clients/TodoItemClient.scala
@@ -34,7 +34,3 @@ trait TodoItemClient[F[_]] {
   def remove(id: Int): F[Int]
 
 }
-
-object TodoItemClient {
-  trait Handler[G[_]] extends TodoItemClient[G]
-}

--- a/modules/examples/todolist/client/src/main/scala/clients/TodoListClient.scala
+++ b/modules/examples/todolist/client/src/main/scala/clients/TodoListClient.scala
@@ -17,11 +17,8 @@
 package examples.todolist.client
 package clients
 
-import freestyle.tagless.tagless
-
 import examples.todolist.protocol.Protocols._
 
-@tagless(true)
 trait TodoListClient[F[_]] {
 
   def reset(): F[Int]
@@ -36,4 +33,8 @@ trait TodoListClient[F[_]] {
 
   def remove(id: Int): F[Int]
 
+}
+
+object TodoListClient {
+  trait Handler[G[_]] extends TodoListClient[G]
 }

--- a/modules/examples/todolist/client/src/main/scala/clients/TodoListClient.scala
+++ b/modules/examples/todolist/client/src/main/scala/clients/TodoListClient.scala
@@ -34,7 +34,3 @@ trait TodoListClient[F[_]] {
   def remove(id: Int): F[Int]
 
 }
-
-object TodoListClient {
-  trait Handler[G[_]] extends TodoListClient[G]
-}

--- a/modules/examples/todolist/client/src/main/scala/handlers/PingPongClientHandler.scala
+++ b/modules/examples/todolist/client/src/main/scala/handlers/PingPongClientHandler.scala
@@ -25,7 +25,7 @@ import freestyle.rpc.protocol.Empty
 import org.log4s._
 
 class PingPongClientHandler[F[_]](implicit M: Functor[F], client: PingPongService.Client[F])
-    extends PingPongClient.Handler[F] {
+    extends PingPongClient[F] {
 
   val logger: Logger = getLogger
 

--- a/modules/examples/todolist/client/src/main/scala/handlers/TagClientHandler.scala
+++ b/modules/examples/todolist/client/src/main/scala/handlers/TagClientHandler.scala
@@ -29,7 +29,7 @@ class TagClientHandler[F[_]](
     implicit M: Monad[F],
     log: LoggingM[F],
     client: TagRpcService.Client[F])
-    extends TagClient.Handler[F] {
+    extends TagClient[F] {
 
   override def reset(): F[Int] =
     for {

--- a/modules/examples/todolist/client/src/main/scala/handlers/TodoItemClientHandler.scala
+++ b/modules/examples/todolist/client/src/main/scala/handlers/TodoItemClientHandler.scala
@@ -29,7 +29,7 @@ class TodoItemClientHandler[F[_]](
     implicit M: Monad[F],
     log: LoggingM[F],
     client: TodoItemRpcService.Client[F])
-    extends TodoItemClient.Handler[F] {
+    extends TodoItemClient[F] {
 
   override def reset(): F[Int] =
     for {

--- a/modules/examples/todolist/client/src/main/scala/handlers/TodoListClientHandler.scala
+++ b/modules/examples/todolist/client/src/main/scala/handlers/TodoListClientHandler.scala
@@ -29,7 +29,7 @@ class TodoListClientHandler[F[_]](
     implicit M: Monad[F],
     log: LoggingM[F],
     client: TodoListRpcService.Client[F])
-    extends TodoListClient.Handler[F] {
+    extends TodoListClient[F] {
 
   override def reset(): F[Int] =
     for {

--- a/modules/server/src/main/scala/GrpcServer.scala
+++ b/modules/server/src/main/scala/GrpcServer.scala
@@ -17,7 +17,6 @@
 package freestyle.rpc
 package server
 
-import freestyle.tagless.tagless
 import cats.~>
 import io.grpc._
 
@@ -74,9 +73,5 @@ trait GrpcServer[F[_]] { self =>
 }
 
 object GrpcServer {
-
-  trait Handler[G[_]] extends GrpcServer[G]
-
   def apply[F[_]](implicit F: GrpcServer[F]): GrpcServer[F] = F
-
 }

--- a/modules/server/src/main/scala/GrpcServer.scala
+++ b/modules/server/src/main/scala/GrpcServer.scala
@@ -18,12 +18,12 @@ package freestyle.rpc
 package server
 
 import freestyle.tagless.tagless
+import cats.~>
 import io.grpc._
 
 import scala.concurrent.duration.TimeUnit
 
-@tagless(true)
-trait GrpcServer[F[_]] {
+trait GrpcServer[F[_]] { self =>
 
   def start(): F[Server]
 
@@ -46,5 +46,37 @@ trait GrpcServer[F[_]] {
   def awaitTerminationTimeout(timeout: Long, unit: TimeUnit): F[Boolean]
 
   def awaitTermination(): F[Unit]
+
+  def mapK[G[_]](fk: F ~> G): GrpcServer[G] = new GrpcServer[G] {
+    def start(): G[Server] = fk(self.start)
+
+    def getPort: G[Int] = fk(self.getPort)
+
+    def getServices: G[List[ServerServiceDefinition]] = fk(self.getServices)
+
+    def getImmutableServices: G[List[ServerServiceDefinition]] = fk(self.getImmutableServices)
+
+    def getMutableServices: G[List[ServerServiceDefinition]] = fk(self.getMutableServices)
+
+    def shutdown(): G[Server] = fk(self.shutdown)
+
+    def shutdownNow(): G[Server] = fk(self.shutdownNow)
+
+    def isShutdown: G[Boolean] = fk(self.isShutdown)
+
+    def isTerminated: G[Boolean] = fk(self.isTerminated)
+
+    def awaitTerminationTimeout(timeout: Long, unit: TimeUnit): G[Boolean] =
+      fk(self.awaitTerminationTimeout(timeout, unit))
+
+    def awaitTermination(): G[Unit] = fk(self.awaitTermination)
+  }
+}
+
+object GrpcServer {
+
+  trait Handler[G[_]] extends GrpcServer[G]
+
+  def apply[F[_]](implicit F: GrpcServer[F]): GrpcServer[F] = F
 
 }

--- a/modules/server/src/main/scala/handlers/GrpcServerHandler.scala
+++ b/modules/server/src/main/scala/handlers/GrpcServerHandler.scala
@@ -25,7 +25,7 @@ import io.grpc.{Server, ServerServiceDefinition}
 import scala.collection.JavaConverters._
 import scala.concurrent.duration.TimeUnit
 
-class GrpcServerHandler[F[_]: Applicative] extends GrpcServer.Handler[GrpcServerOps[F, ?]] {
+class GrpcServerHandler[F[_]: Applicative] extends GrpcServer[GrpcServerOps[F, ?]] {
 
   def start: GrpcServerOps[F, Server] = captureWithServer { server =>
     Runtime.getRuntime.addShutdownHook(new Thread() {

--- a/modules/server/src/test/scala/protocol/Utils.scala
+++ b/modules/server/src/test/scala/protocol/Utils.scala
@@ -22,7 +22,6 @@ import cats.effect.Async
 import cats.syntax.applicative._
 import freestyle.rpc.common._
 import freestyle.rpc.server.implicits._
-import freestyle.tagless.tagless
 import io.grpc.Status
 import monix.reactive.Observable
 
@@ -142,8 +141,7 @@ object Utils extends CommonUtils {
 
   object client {
 
-    @tagless(true)
-    trait MyRPCClient[F[_]] {
+    trait MyRPCClient[F[_]] { self =>
       def notAllowed(b: Boolean): F[C]
       def empty: F[Empty.type]
       def emptyParam(a: A): F[Empty.type]
@@ -163,6 +161,14 @@ object Utils extends CommonUtils {
       def cs(cList: List[C], bar: Int): F[D]
       def bs(eList: List[E]): F[E]
       def bsws(eList: List[E]): F[E]
+    }
+
+    object MyRPCClient {
+
+      trait Handler[G[_]] extends MyRPCClient[G]
+
+      def apply[F[_]](implicit F: MyRPCClient[F]): MyRPCClient[F] = F
+
     }
 
   }

--- a/modules/server/src/test/scala/protocol/Utils.scala
+++ b/modules/server/src/test/scala/protocol/Utils.scala
@@ -141,7 +141,7 @@ object Utils extends CommonUtils {
 
   object client {
 
-    trait MyRPCClient[F[_]] { self =>
+    trait MyRPCClient[F[_]] {
       def notAllowed(b: Boolean): F[C]
       def empty: F[Empty.type]
       def emptyParam(a: A): F[Empty.type]
@@ -161,14 +161,6 @@ object Utils extends CommonUtils {
       def cs(cList: List[C], bar: Int): F[D]
       def bs(eList: List[E]): F[E]
       def bsws(eList: List[E]): F[E]
-    }
-
-    object MyRPCClient {
-
-      trait Handler[G[_]] extends MyRPCClient[G]
-
-      def apply[F[_]](implicit F: MyRPCClient[F]): MyRPCClient[F] = F
-
     }
 
   }
@@ -313,7 +305,7 @@ object Utils extends CommonUtils {
       class FreesRPCServiceClientHandler[F[_]: Async](
           implicit client: RPCService.Client[F],
           M: MonadError[F, Throwable])
-          extends MyRPCClient.Handler[F] {
+          extends MyRPCClient[F] {
 
         override def notAllowed(b: Boolean): F[C] =
           client.notAllowed(b)
@@ -419,7 +411,7 @@ object Utils extends CommonUtils {
       class FreesRPCServiceClientCompressedHandler[F[_]: Async](
           implicit client: RPCService.Client[F],
           M: MonadError[F, Throwable])
-          extends MyRPCClient.Handler[F] {
+          extends MyRPCClient[F] {
 
         override def notAllowed(b: Boolean): F[C] =
           client.notAllowedCompressed(b)


### PR DESCRIPTION
~Currently, most of the implementaitions only needed the `Handler[F]`
type in the companion.~ Not even that :)

FIXES #292