### PR TITLE
Decouple frees config

### DIFF
--- a/docs/src/main/tut/core-concepts.md
+++ b/docs/src/main/tut/core-concepts.md
@@ -225,10 +225,11 @@ trait CommonRuntime {
 ```
 
 ```tut:silent
+import cats.effect.IO
 import cats.implicits._
-import freestyle.free.config.implicits._
 import freestyle.async.catsEffect.implicits._
 import freestyle.rpc._
+import freestyle.rpc.config._
 import freestyle.rpc.client._
 import freestyle.rpc.client.config._
 import freestyle.rpc.client.implicits._
@@ -241,12 +242,7 @@ import scala.util.{Failure, Success, Try}
 trait Implicits extends CommonRuntime {
 
   val channelFor: ChannelFor =
-    ConfigForAddress[Try]("rpc.host", "rpc.port") match {
-      case Success(c) => c
-      case Failure(e) =>
-        e.printStackTrace()
-        throw new RuntimeException("Unable to load the client configuration", e)
-    }
+    ConfigForAddress[IO]("rpc.host", "rpc.port").unsafeRunSync
 
   implicit val serviceClient: Greeter.Client[Task] =
     Greeter.client[Task](channelFor, options = CallOptions.DEFAULT.withCompression("gzip"))

--- a/docs/src/main/tut/metrics-reporting.md
+++ b/docs/src/main/tut/metrics-reporting.md
@@ -101,9 +101,9 @@ In this case, in order to intercept the client calls we need additional configur
 ```tut:silent
 import cats.implicits._
 import cats.effect.IO
-import freestyle.free.config.implicits._
 import freestyle.async.catsEffect.implicits._
 import freestyle.rpc._
+import freestyle.rpc.config._
 import freestyle.rpc.client._
 import freestyle.rpc.client.config._
 import freestyle.rpc.client.implicits._
@@ -119,12 +119,7 @@ import freestyle.rpc.prometheus.client.MonitoringClientInterceptor
 object InterceptingClientCalls extends CommonRuntime {
 
   val channelFor: ChannelFor =
-    ConfigForAddress[Try]("rpc.host", "rpc.port") match {
-      case Success(c) => c
-      case Failure(e) =>
-        e.printStackTrace()
-        throw new RuntimeException("Unable to load the client configuration", e)
-      }
+    ConfigForAddress[IO]("rpc.host", "rpc.port").unsafeRunSync
 
   implicit val serviceClient: Greeter.Client[Task] =
     Greeter.client[Task](

--- a/docs/src/main/tut/patterns.md
+++ b/docs/src/main/tut/patterns.md
@@ -280,9 +280,9 @@ So, taking into account all we have just said, how would our code look?
 ```tut:silent
 import cats.implicits._
 import cats.effect.IO
-import freestyle.free.config.implicits._
 import freestyle.async.catsEffect.implicits._
 import freestyle.rpc._
+import freestyle.rpc.config._
 import freestyle.rpc.client._
 import freestyle.rpc.client.config._
 import freestyle.rpc.client.implicits._
@@ -297,12 +297,7 @@ object gclient {
   trait Implicits extends CommonRuntime {
 
     val channelFor: ChannelFor =
-      ConfigForAddress[Try]("rpc.host", "rpc.port") match {
-        case Success(c) => c
-        case Failure(e) =>
-          e.printStackTrace()
-          throw new RuntimeException("Unable to load the client configuration", e)
-    }
+      ConfigForAddress[IO]("rpc.host", "rpc.port").unsafeRunSync
 
     implicit val serviceClient: Greeter.Client[Task] =
       Greeter.client[Task](channelFor)

--- a/modules/config/src/main/scala/client/ChannelConfig.scala
+++ b/modules/config/src/main/scala/client/ChannelConfig.scala
@@ -27,36 +27,31 @@ import freestyle.rpc.config.ConfigM
 
 import com.typesafe.config.ConfigException.Missing
 
-trait ChannelConfig[F[_]] {
-
-  implicit def sync: Sync[F]
-  implicit def configM: ConfigM[F]
+class ChannelConfig[F[_]](implicit S: Sync[F], C: ConfigM[F]) {
 
   val defaultHost: String = "localhost"
   val defaultPort: Int    = freestyle.rpc.server.defaultPort
 
   def loadChannelAddress(hostPath: String, portPath: String): F[ChannelForAddress] =
     for {
-      config <- configM.load
-      host <- sync.pure(
+      config <- C.load
+      host <- S.pure(
         Either
           .catchOnly[Missing](config.getString(hostPath)))
-      port <- sync.pure(Either.catchOnly[Missing](config.getInt(portPath)))
+      port <- S.pure(Either.catchOnly[Missing](config.getInt(portPath)))
     } yield ChannelForAddress(host.getOrElse(defaultHost), port.getOrElse(defaultPort))
 
   def loadChannelTarget(targetPath: String): F[ChannelForTarget] =
     for {
-      config <- configM.load
-      target <- sync.pure(Either.catchOnly[Missing](config.getString(targetPath)))
+      config <- C.load
+      target <- S.pure(Either.catchOnly[Missing](config.getString(targetPath)))
     } yield ChannelForTarget(target.getOrElse("target"))
 
 }
 
 object ChannelConfig {
-  def apply[F[_]](implicit S: Sync[F], C: ConfigM[F]): ChannelConfig[F] = new ChannelConfig[F] {
-    def sync    = S
-    def configM = C
-  }
+  def apply[F[_]](implicit S: Sync[F], C: ConfigM[F]): ChannelConfig[F] =
+    new ChannelConfig[F]
 
   implicit def defaultChannelConfig[F[_]](implicit S: Sync[F], C: ConfigM[F]): ChannelConfig[F] =
     apply[F](S, C)

--- a/modules/config/src/main/scala/config.scala
+++ b/modules/config/src/main/scala/config.scala
@@ -15,26 +15,19 @@
  */
 
 package freestyle.rpc
-package client
-package config
 
-import freestyle.rpc.common.{ConcurrentMonad, SC}
+import cats.effect.Sync
+import pureconfig._
+import com.typesafe.config.{Config, ConfigFactory}
 
-class ChannelConfigTests extends RpcClientTestSuite {
+object config {
 
-  "ChannelConfig" should {
+  trait ConfigM[F[_]] {
+    def load: F[Config]
+  }
 
-    "for Address [host, port] work as expected" in {
-      ConfigForAddress[ConcurrentMonad](SC.host, SC.port.toString).unsafeRunSync shouldBe ChannelForAddress(
-        "localhost",
-        50051)
-    }
-
-    "for Target work as expected" in {
-
-      ConfigForTarget[ConcurrentMonad](SC.host).unsafeRunSync shouldBe ChannelForTarget("target")
-    }
-
+  implicit def syncConfigM[F[_]](implicit F: Sync[F]): ConfigM[F] = new ConfigM[F] {
+    def load: F[Config] = F.delay(loadConfigOrThrow[Config](ConfigFactory.load()))
   }
 
 }

--- a/modules/config/src/main/scala/server/ServerConfig.scala
+++ b/modules/config/src/main/scala/server/ServerConfig.scala
@@ -18,26 +18,44 @@ package freestyle.rpc
 package server
 package config
 
-import cats.Functor
-import cats.syntax.either._
+import cats.effect.Sync
+import cats.syntax.flatMap._
 import cats.syntax.functor._
-import freestyle.tagless._
-import freestyle.tagless.config.ConfigM
+import cats.syntax.either._
 
-@module
-trait ServerConfig {
+import freestyle.rpc.config.ConfigM
 
-  val configM: ConfigM
-  implicit val functor: Functor
+import com.typesafe.config.ConfigException.Missing
 
-  def buildServer(portPath: String, configList: List[GrpcConfig] = Nil): FS[ServerW] =
-    configM.load.map { config =>
-      val port = config.int(portPath).getOrElse(defaultPort)
-      ServerW.default(port, configList)
-    }
+trait ServerConfig[F[_]] {
 
-  def buildNettyServer(portPath: String, configList: List[GrpcConfig] = Nil): FS[ServerW] =
-    configM.load.map { config =>
-      ServerW.netty(ChannelForPort(config.int(portPath).getOrElse(defaultPort)), configList)
-    }
+  implicit def sync: Sync[F]
+  implicit def configM: ConfigM[F]
+
+  def buildServer(portPath: String, configList: List[GrpcConfig] = Nil): F[ServerW] =
+    for {
+      config <- configM.load
+      port <- sync.pure(
+        Either
+          .catchOnly[Missing](config.getInt(portPath)))
+    } yield ServerW.default(port.getOrElse(defaultPort), configList)
+
+  def buildNettyServer(portPath: String, configList: List[GrpcConfig] = Nil): F[ServerW] =
+    for {
+      config <- configM.load
+      port <- sync.pure(
+        Either
+          .catchOnly[Missing](config.getInt(portPath)))
+    } yield ServerW.netty(ChannelForPort(port.getOrElse(defaultPort)), configList)
+}
+
+object ServerConfig {
+  def apply[F[_]](implicit S: Sync[F], C: ConfigM[F]): ServerConfig[F] = new ServerConfig[F] {
+    def sync    = S
+    def configM = C
+  }
+
+  implicit def defaultServerConfig[F[_]](implicit S: Sync[F], C: ConfigM[F]): ServerConfig[F] =
+    apply[F](S, C)
+
 }

--- a/modules/config/src/test/scala/server/ServerConfigTests.scala
+++ b/modules/config/src/test/scala/server/ServerConfigTests.scala
@@ -18,7 +18,6 @@ package freestyle.rpc
 package server
 package config
 
-import freestyle.tagless.config.implicits._
 import freestyle.rpc.common.{ConcurrentMonad, SC}
 
 import scala.concurrent.ExecutionContext
@@ -27,7 +26,7 @@ class ServerConfigTests extends RpcServerTestSuite {
 
   implicit val ec: ExecutionContext = ExecutionContext.Implicits.global
 
-  "ServerConfig.Op" should {
+  "ServerConfig" should {
 
     "load the port specified in the config file" in {
 

--- a/modules/examples/routeguide/client/src/main/scala/runtime/ClientConf.scala
+++ b/modules/examples/routeguide/client/src/main/scala/runtime/ClientConf.scala
@@ -19,7 +19,6 @@ package example.routeguide.client.runtime
 import cats.effect.IO
 import freestyle.rpc.ChannelFor
 import freestyle.rpc.client.config.ConfigForAddress
-import freestyle.tagless.config.implicits._
 
 trait ClientConf {
 

--- a/modules/examples/routeguide/server/src/main/scala/implicits.scala
+++ b/modules/examples/routeguide/server/src/main/scala/implicits.scala
@@ -20,7 +20,6 @@ import cats.effect.IO
 import freestyle.rpc.server._
 import freestyle.rpc.server.config.BuildServerFromConfig
 import freestyle.rpc.server.{AddService, GrpcConfig, ServerW}
-import freestyle.tagless.config.implicits._
 import example.routeguide.server.handlers.RouteGuideServiceHandler
 import example.routeguide.protocol.Protocols.RouteGuideService
 import example.routeguide.runtime._

--- a/modules/examples/todolist/client/src/main/scala/implicits.scala
+++ b/modules/examples/todolist/client/src/main/scala/implicits.scala
@@ -20,7 +20,6 @@ import cats.effect.IO
 import examples.todolist.client.handlers._
 import examples.todolist.protocol.Protocols._
 import freestyle.tagless.loggingJVM.log4s.implicits._
-import freestyle.tagless.config.implicits._
 import examples.todolist.runtime.CommonRuntime
 import freestyle.rpc.ChannelFor
 import freestyle.rpc.client.config.ConfigForAddress

--- a/modules/examples/todolist/server/src/main/scala/implicits.scala
+++ b/modules/examples/todolist/server/src/main/scala/implicits.scala
@@ -28,7 +28,6 @@ import examples.todolist.server.handlers._
 import freestyle.rpc.server._
 import freestyle.rpc.server.config.BuildServerFromConfig
 import freestyle.rpc.server.{AddService, GrpcConfig, ServerW}
-import freestyle.tagless.config.implicits._
 import freestyle.tagless.loggingJVM.log4s.implicits._
 import java.util.Properties
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -164,7 +164,7 @@ object ProjectPlugin extends AutoPlugin {
 
     lazy val exampleTodolistCommonSettings: Seq[Def.Setting[_]] = Seq(
       libraryDependencies ++= Seq(
-        "io.frees" %% "frees-todolist-lib" % "0.8.1-SNAPSHOT",
+        "io.frees" %% "frees-todolist-lib" % V.frees,
         %%("log4s", V.log4s),
         %("logback-classic", V.logback)
       )

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -92,7 +92,7 @@ object ProjectPlugin extends AutoPlugin {
 
     lazy val configSettings = Seq(
       libraryDependencies ++= Seq(
-        %%("frees-config", V.frees)
+        %%("pureconfig")
       )
     )
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -23,7 +23,7 @@ object ProjectPlugin extends AutoPlugin {
       val avrohugger: String         = "1.0.0-RC10"
       val catsEffect: String         = "0.10.1"
       val circe: String              = "0.9.3"
-      val frees: String              = "0.8.0"
+      val frees: String              = "0.8.1"
       val fs2ReactiveStreams: String = "0.5.1"
       val grpc: String               = "1.11.0"
       val log4s: String              = "1.6.1"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += Resolver.sonatypeRepo("releases")
 resolvers += Resolver.sonatypeRepo("snapshots")
 
-addSbtPlugin("io.frees"     % "sbt-freestyle" % "0.3.21")
+addSbtPlugin("io.frees"     % "sbt-freestyle" % "0.3.23")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.8.0")
 
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value


### PR DESCRIPTION
In this PR I:

- create a bare minimum `ConfigM` tagless to be used wherever `freestyle.tagless.config` were used before
- remove a couple of `@module` annotations
- bump `frees-todolist-lib`to `v0.8.1`
- bump sbt-freestyle to `0.3.23`

FIXES #294 