### PR TITLE
Downgrade avro4s to 1.8.3

### DIFF
--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -19,7 +19,7 @@ object ProjectPlugin extends AutoPlugin {
   object autoImport {
 
     lazy val V = new {
-      val avro4s: String             = "1.9.0"
+      val avro4s: String             = "1.8.3"
       val avrohugger: String         = "1.0.0-RC10"
       val catsEffect: String         = "0.10.1"
       val circe: String              = "0.9.3"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.13.6-SNAPSHOT"
+version in ThisBuild := "0.13.6"


### PR DESCRIPTION
This PR downgrades `avro4s` to `1.8.3`, but keeps `avrohugger` up to date, so `decimal` and `date` types continue working.

This downgrade is necessary to until issue #288 is solved.

It also sets freestyle-rpc version to `0.13.6`