### PR TITLE
Decouples frees-async-cats-effect

### DIFF
--- a/docs/src/main/tut/core-concepts.md
+++ b/docs/src/main/tut/core-concepts.md
@@ -227,7 +227,6 @@ trait CommonRuntime {
 ```tut:silent
 import cats.effect.IO
 import cats.implicits._
-import freestyle.async.catsEffect.implicits._
 import freestyle.rpc._
 import freestyle.rpc.config._
 import freestyle.rpc.client._

--- a/docs/src/main/tut/metrics-reporting.md
+++ b/docs/src/main/tut/metrics-reporting.md
@@ -67,7 +67,6 @@ import cats.effect.IO
 import freestyle.rpc.server._
 import freestyle.rpc.server.handlers._
 import freestyle.rpc.server.implicits._
-import freestyle.async.catsEffect.implicits._
 import freestyle.rpc.prometheus.shared.Configuration
 import freestyle.rpc.prometheus.server.MonitoringServerInterceptor
 import io.prometheus.client.CollectorRegistry
@@ -101,7 +100,6 @@ In this case, in order to intercept the client calls we need additional configur
 ```tut:silent
 import cats.implicits._
 import cats.effect.IO
-import freestyle.async.catsEffect.implicits._
 import freestyle.rpc._
 import freestyle.rpc.config._
 import freestyle.rpc.client._

--- a/docs/src/main/tut/patterns.md
+++ b/docs/src/main/tut/patterns.md
@@ -157,7 +157,6 @@ import cats.effect.IO
 import freestyle.rpc.server._
 import freestyle.rpc.server.handlers._
 import freestyle.rpc.server.implicits._
-import freestyle.async.catsEffect.implicits._
 import service._
 
 object gserver {
@@ -280,7 +279,6 @@ So, taking into account all we have just said, how would our code look?
 ```tut:silent
 import cats.implicits._
 import cats.effect.IO
-import freestyle.async.catsEffect.implicits._
 import freestyle.rpc._
 import freestyle.rpc.config._
 import freestyle.rpc.client._

--- a/modules/examples/todolist/protocol/src/main/scala/TagProtocol.scala
+++ b/modules/examples/todolist/protocol/src/main/scala/TagProtocol.scala
@@ -17,7 +17,6 @@
 package examples.todolist
 package protocol
 
-import examples.todolist.protocol.MessageId
 import freestyle.rpc.protocol._
 
 trait TagProtocol {

--- a/modules/examples/todolist/protocol/src/main/scala/TodoItemProtocol.scala
+++ b/modules/examples/todolist/protocol/src/main/scala/TodoItemProtocol.scala
@@ -33,7 +33,6 @@
 package examples.todolist
 package protocol
 
-import examples.todolist.protocol.MessageId
 import freestyle.rpc.protocol._
 
 trait TodoItemProtocol {

--- a/modules/examples/todolist/protocol/src/main/scala/TodoListProtocol.scala
+++ b/modules/examples/todolist/protocol/src/main/scala/TodoListProtocol.scala
@@ -17,7 +17,6 @@
 package examples.todolist
 package protocol
 
-import examples.todolist.protocol.MessageId
 import freestyle.rpc.protocol._
 
 trait TodoListProtocol {

--- a/modules/internal/src/main/scala/service.scala
+++ b/modules/internal/src/main/scala/service.scala
@@ -20,7 +20,7 @@ package internal
 import cats.instances.list._
 import cats.syntax.foldable._
 
-import freestyle.free.internal.ScalametaUtil
+import freestyle.rpc.internal.util.ScalametaUtil
 import freestyle.rpc.protocol._
 
 import scala.collection.immutable.Seq

--- a/modules/internal/src/main/scala/util/ScalametaUtil.scala
+++ b/modules/internal/src/main/scala/util/ScalametaUtil.scala
@@ -20,9 +20,15 @@ package util
 
 import scala.meta.Mod.Annot
 import scala.meta.Term.Apply
+import scala.meta.Defn.Class
 import scala.meta._
 
 object ScalametaUtil {
+
+  def isAbstract(cls: Class): Boolean = cls.mods.exists {
+    case Mod.Abstract() => true
+    case _              => false
+  }
 
   implicit class DefnOps(val defn: Defn) extends AnyVal {
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -50,7 +50,7 @@ object ProjectPlugin extends AutoPlugin {
 
     lazy val internalSettings: Seq[Def.Setting[_]] = Seq(
       libraryDependencies ++= Seq(
-        %%("frees-async-cats-effect", V.frees),
+        %%("cats-effect", V.catsEffect),
         %("grpc-stub", V.grpc),
         %%("monix"),
         %%("fs2-reactive-streams", V.fs2ReactiveStreams),
@@ -63,7 +63,7 @@ object ProjectPlugin extends AutoPlugin {
 
     lazy val clientCoreSettings: Seq[Def.Setting[_]] = Seq(
       libraryDependencies ++= Seq(
-        %%("frees-async-cats-effect", V.frees),
+        %%("cats-effect", V.catsEffect),
         %%("scalamockScalatest") % Test,
         %("grpc-netty", V.grpc)  % Test
       )


### PR DESCRIPTION
Fixes https://github.com/frees-io/freestyle-rpc/issues/293
Fixes https://github.com/frees-io/freestyle-rpc/issues/295

This PR completes the work removing all the freestyle dependencies from `frees-rpc`, as part of the #290  milestone. It copies from [Freestyle](https://github.com/frees-io/freestyle/blob/8d6366a8383a22737daea9fc325e6d4f111df27f/modules/core/shared/src/main/scala/freestyle/free/internal/ScalametaUtil.scala#L26-L29) the `isAbstract` utility, in order to complete the decoupling.