### PR TITLE
Fixes options and lists serialization in proto

### DIFF
--- a/modules/internal/src/main/scala/service.scala
+++ b/modules/internal/src/main/scala/service.scala
@@ -157,11 +157,15 @@ object serviceImpl {
 
       val encodersImport = serializationType match {
         case Protobuf =>
-          q"import _root_.freestyle.rpc.internal.encoders.pbd._"
+          List(
+            q"import _root_.cats.instances.list._",
+            q"import _root_.cats.instances.option._",
+            q"import _root_.freestyle.rpc.internal.encoders.pbd._"
+          )
         case Avro =>
-          q"import _root_.freestyle.rpc.internal.encoders.avro._"
+          List(q"import _root_.freestyle.rpc.internal.encoders.avro._")
         case AvroWithSchema =>
-          q"import _root_.freestyle.rpc.internal.encoders.avrowithschema._"
+          List(q"import _root_.freestyle.rpc.internal.encoders.avrowithschema._")
       }
 
       val methodDescriptors: List[Tree] = rpcRequests.map(_.methodDescriptor)
@@ -390,8 +394,7 @@ object serviceImpl {
           Template(
             companion.impl.parents,
             companion.impl.self,
-            companion.impl.body ++ service.imports ++ service.methodDescriptors ++ List(
-              service.encodersImport,
+            companion.impl.body ++ service.imports ++ service.methodDescriptors ++ service.encodersImport ++ List(
               service.bindService,
               service.clientClass,
               service.client,

--- a/modules/server/src/test/scala/protocol/RPCProtoProducts.scala
+++ b/modules/server/src/test/scala/protocol/RPCProtoProducts.scala
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc
+package protocol
+
+import cats.Applicative
+import cats.syntax.applicative._
+import freestyle.rpc.common._
+import freestyle.rpc.testing.servers.withServerChannel
+import org.scalatest._
+import org.scalacheck.Prop._
+import org.scalatest.prop.Checkers
+
+class RPCProtoProducts extends RpcBaseTestSuite with BeforeAndAfterAll with Checkers {
+
+  object RPCService {
+
+    case class MyParam(value: String)
+
+    case class RequestOption(param1: Option[MyParam])
+
+    case class ResponseOption(param1: Option[String], param2: Boolean)
+
+    case class RequestList(param1: List[MyParam])
+
+    case class ResponseList(param1: List[String], param2: Boolean)
+
+    @service(Protobuf)
+    trait ProtoRPCServiceDef[F[_]] {
+      def optionProto(req: RequestOption): F[ResponseOption]
+      def listProto(req: RequestList): F[ResponseList]
+    }
+
+    @service(Avro)
+    trait AvroRPCServiceDef[F[_]] {
+      def optionAvro(req: RequestOption): F[ResponseOption]
+      def listAvro(req: RequestList): F[ResponseList]
+    }
+
+    @service(AvroWithSchema)
+    trait AvroWithSchemaRPCServiceDef[F[_]] {
+      def optionAvroWithSchema(req: RequestOption): F[ResponseOption]
+      def listAvroWithSchema(req: RequestList): F[ResponseList]
+    }
+
+    class RPCServiceDefImpl[F[_]: Applicative]
+        extends ProtoRPCServiceDef[F]
+        with AvroRPCServiceDef[F]
+        with AvroWithSchemaRPCServiceDef[F] {
+
+      def optionProto(req: RequestOption): F[ResponseOption] =
+        ResponseOption(req.param1.map(_.value), true).pure
+      def optionAvro(req: RequestOption): F[ResponseOption] =
+        ResponseOption(req.param1.map(_.value), true).pure
+      def optionAvroWithSchema(req: RequestOption): F[ResponseOption] =
+        ResponseOption(req.param1.map(_.value), true).pure
+
+      def listProto(req: RequestList): F[ResponseList] =
+        ResponseList(req.param1.map(_.value), true).pure
+      def listAvro(req: RequestList): F[ResponseList] =
+        ResponseList(req.param1.map(_.value), true).pure
+      def listAvroWithSchema(req: RequestList): F[ResponseList] =
+        ResponseList(req.param1.map(_.value), true).pure
+    }
+
+  }
+
+  "A RPC server" should {
+
+    import RPCService._
+    import monix.execution.Scheduler.Implicits.global
+
+    implicit val H: RPCServiceDefImpl[ConcurrentMonad] =
+      new RPCServiceDefImpl[ConcurrentMonad]
+
+    "be able to serialize and deserialize Options in the request/response using proto format" in {
+
+      withServerChannel(ProtoRPCServiceDef.bindService[ConcurrentMonad]) { sc =>
+        val client: ProtoRPCServiceDef.Client[ConcurrentMonad] =
+          ProtoRPCServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+
+        check {
+          forAll { maybeString: Option[String] =>
+            client
+              .optionProto(RequestOption(maybeString.map(MyParam)))
+              .unsafeRunSync() == ResponseOption(maybeString, true)
+          }
+        }
+
+      }
+
+    }
+
+    "be able to serialize and deserialize Options in the request/response using avro format" in {
+
+      withServerChannel(AvroRPCServiceDef.bindService[ConcurrentMonad]) { sc =>
+        val client: AvroRPCServiceDef.Client[ConcurrentMonad] =
+          AvroRPCServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+
+        check {
+          forAll { maybeString: Option[String] =>
+            client
+              .optionAvro(RequestOption(maybeString.map(MyParam)))
+              .unsafeRunSync() == ResponseOption(maybeString, true)
+          }
+        }
+
+      }
+
+    }
+
+    "be able to serialize and deserialize Options in the request/response using avro with schema format" in {
+
+      withServerChannel(AvroWithSchemaRPCServiceDef.bindService[ConcurrentMonad]) { sc =>
+        val client: AvroWithSchemaRPCServiceDef.Client[ConcurrentMonad] =
+          AvroWithSchemaRPCServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+
+        check {
+          forAll { maybeString: Option[String] =>
+            client
+              .optionAvroWithSchema(RequestOption(maybeString.map(MyParam)))
+              .unsafeRunSync() == ResponseOption(maybeString, true)
+          }
+        }
+
+      }
+
+    }
+
+    "be able to serialize and deserialize Lists in the request/response using proto format" in {
+
+      withServerChannel(ProtoRPCServiceDef.bindService[ConcurrentMonad]) { sc =>
+        val client: ProtoRPCServiceDef.Client[ConcurrentMonad] =
+          ProtoRPCServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+
+        check {
+          forAll { list: List[String] =>
+            client
+              .listProto(RequestList(list.map(MyParam)))
+              .unsafeRunSync() == ResponseList(list, true)
+          }
+        }
+
+      }
+
+    }
+
+    "be able to serialize and deserialize Lists in the request/response using avro format" in {
+
+      withServerChannel(AvroRPCServiceDef.bindService[ConcurrentMonad]) { sc =>
+        val client: AvroRPCServiceDef.Client[ConcurrentMonad] =
+          AvroRPCServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+
+        check {
+          forAll { list: List[String] =>
+            client
+              .listAvro(RequestList(list.map(MyParam)))
+              .unsafeRunSync() == ResponseList(list, true)
+          }
+        }
+
+      }
+
+    }
+
+    "be able to serialize and deserialize Lists in the request/response using avro with schema format" in {
+
+      withServerChannel(AvroWithSchemaRPCServiceDef.bindService[ConcurrentMonad]) { sc =>
+        val client: AvroWithSchemaRPCServiceDef.Client[ConcurrentMonad] =
+          AvroWithSchemaRPCServiceDef.clientFromChannel[ConcurrentMonad](sc.channel)
+
+        check {
+          forAll { list: List[String] =>
+            client
+              .listAvroWithSchema(RequestList(list.map(MyParam)))
+              .unsafeRunSync() == ResponseList(list, true)
+          }
+        }
+
+      }
+
+    }
+  }
+
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.14.1-SNAPSHOT"
+version in ThisBuild := "0.14.1"


### PR DESCRIPTION
Fixes #285 

Thanks to @btlines that pointed me in the right direction (see https://github.com/btlines/pbdirect/issues/21)

> To serialise Option correctly you need to import cats.implicits._ or more specifically import cats.instances.option._. (I suppose you have this import clause present in your tests somehow).
> 
> The reason is that pbdirect knows how to serialise a functor but for this to work it needs an evidence that Option is a Functor and this is provided by importing cats implicits.