### PR TITLE
Allows Custom namespace for server/client metrics

### DIFF
--- a/modules/dropwizard/client/src/test/scala/MonitorClientInterceptorTests.scala
+++ b/modules/dropwizard/client/src/test/scala/MonitorClientInterceptorTests.scala
@@ -27,6 +27,8 @@ class MonitorClientInterceptorTests extends BaseMonitorClientInterceptorTests {
 
   override def name: String = "Dropwizard"
 
+  override def namespace: Option[String] = Some("grpc")
+
   def defaultClientRuntime: InterceptorsRuntime = {
 
     val metrics: MetricRegistry      = new MetricRegistry

--- a/modules/dropwizard/server/src/test/scala/MonitorServerInterceptorTests.scala
+++ b/modules/dropwizard/server/src/test/scala/MonitorServerInterceptorTests.scala
@@ -27,6 +27,8 @@ class MonitorServerInterceptorTests extends BaseMonitorServerInterceptorTests {
 
   override def name: String = "Dropwizard"
 
+  override def namespace: Option[String] = Some("grpc")
+
   override def defaultInterceptorsRuntime: InterceptorsRuntime = {
 
     val metrics: MetricRegistry      = new MetricRegistry

--- a/modules/interceptors/src/main/scala/metrics.scala
+++ b/modules/interceptors/src/main/scala/metrics.scala
@@ -32,17 +32,6 @@ final case class MetricType(
 
 }
 
-object MetricType {
-
-  def apply(
-      subsystem: MetricsFor,
-      name: String,
-      labelNames: List[String],
-      description: String): MetricType =
-    MetricType(metrics.namespace, subsystem, name, labelNames, description)
-
-}
-
 object metrics {
 
   // Namespaces:
@@ -72,32 +61,38 @@ object metrics {
 
   // Client - Predefined metrics:
 
-  val clientMetricRpcStarted: MetricType =
+  def clientMetricRpcStarted(nsp: Option[String]): MetricType =
     MetricType(
+      nsp.getOrElse(namespace),
       ClientMetrics,
       startedTotal,
       baseLabels,
       "Total number of RPCs started on the client.")
-  val clientMetricRpcCompleted: MetricType =
+  def clientMetricRpcCompleted(nsp: Option[String]): MetricType =
     MetricType(
+      nsp.getOrElse(namespace),
       ClientMetrics,
       completed,
       baseLabels :+ grpcCode,
-      "Total number of RPCs completed on the client, regardless of success or failure.")
-  val clientMetricCompletedLatencySeconds: MetricType =
+      "Total number of RPCs completed on the client, regardless of success or failure."
+    )
+  def clientMetricCompletedLatencySeconds(nsp: Option[String]): MetricType =
     MetricType(
+      nsp.getOrElse(namespace),
       ClientMetrics,
       completedLatencySeconds,
       baseLabels,
       "Histogram of rpc response latency (in seconds) for completed rpcs.")
-  val clientMetricStreamMessagesReceived: MetricType =
+  def clientMetricStreamMessagesReceived(nsp: Option[String]): MetricType =
     MetricType(
+      nsp.getOrElse(namespace),
       ClientMetrics,
       msgReceivedTotal,
       baseLabels,
       "Total number of stream messages received from the server.")
-  val clientMetricStreamMessagesSent: MetricType =
+  def clientMetricStreamMessagesSent(nsp: Option[String]): MetricType =
     MetricType(
+      nsp.getOrElse(namespace),
       ClientMetrics,
       msgSentTotal,
       baseLabels,
@@ -105,33 +100,39 @@ object metrics {
 
   // Server - Predefined metrics:
 
-  val serverMetricRpcStarted: MetricType =
+  def serverMetricRpcStarted(nsp: Option[String]): MetricType =
     MetricType(
+      nsp.getOrElse(namespace),
       ServerMetrics,
       startedTotal,
       baseLabels,
       "Total number of RPCs started on the server.")
-  val serverMetricHandledCompleted: MetricType =
+  def serverMetricHandledCompleted(nsp: Option[String]): MetricType =
     MetricType(
+      nsp.getOrElse(namespace),
       ServerMetrics,
       handledTotal,
       baseLabels :+ grpcCode,
-      "Total number of RPCs completed on the server, regardless of success or failure.")
-  val serverMetricHandledLatencySeconds: MetricType =
+      "Total number of RPCs completed on the server, regardless of success or failure."
+    )
+  def serverMetricHandledLatencySeconds(nsp: Option[String]): MetricType =
     MetricType(
+      nsp.getOrElse(namespace),
       ServerMetrics,
       handledLatencySeconds,
       baseLabels,
       "Histogram of response latency (seconds) of gRPC that had been application-level handled by the server."
     )
-  val serverMetricStreamMessagesReceived: MetricType =
+  def serverMetricStreamMessagesReceived(nsp: Option[String]): MetricType =
     MetricType(
+      nsp.getOrElse(namespace),
       ServerMetrics,
       msgReceivedTotal,
       baseLabels,
       "Total number of stream messages received from the client.")
-  val serverMetricStreamMessagesSent: MetricType =
+  def serverMetricStreamMessagesSent(nsp: Option[String]): MetricType =
     MetricType(
+      nsp.getOrElse(namespace),
       ServerMetrics,
       msgSentTotal,
       baseLabels,

--- a/modules/prometheus/client/src/main/scala/ClientMetrics.scala
+++ b/modules/prometheus/client/src/main/scala/ClientMetrics.scala
@@ -27,19 +27,19 @@ case class ClientMetrics(cfg: Configuration) {
   import freestyle.rpc.prometheus.implicits._
 
   private[this] val rpcStartedBuilder: Counter.Builder =
-    clientMetricRpcStarted.toCounterBuilder
+    clientMetricRpcStarted(cfg.namespace).toCounterBuilder
 
   private[this] val rpcCompletedBuilder: Counter.Builder =
-    clientMetricRpcCompleted.toCounterBuilder
+    clientMetricRpcCompleted(cfg.namespace).toCounterBuilder
 
   private[this] val completedLatencySecondsBuilder: Histogram.Builder =
-    clientMetricCompletedLatencySeconds.toHistogramBuilder
+    clientMetricCompletedLatencySeconds(cfg.namespace).toHistogramBuilder
 
   private[this] val streamMessagesReceivedBuilder: Counter.Builder =
-    clientMetricStreamMessagesReceived.toCounterBuilder
+    clientMetricStreamMessagesReceived(cfg.namespace).toCounterBuilder
 
   private[this] val streamMessagesSentBuilder: Counter.Builder =
-    clientMetricStreamMessagesSent.toCounterBuilder
+    clientMetricStreamMessagesSent(cfg.namespace).toCounterBuilder
 
   val rpcStarted: Counter   = rpcStartedBuilder.register(cfg.collectorRegistry)
   val rpcCompleted: Counter = rpcCompletedBuilder.register(cfg.collectorRegistry)

--- a/modules/prometheus/client/src/test/scala/MonitorClientInterceptorTests.scala
+++ b/modules/prometheus/client/src/test/scala/MonitorClientInterceptorTests.scala
@@ -24,6 +24,8 @@ class MonitorClientInterceptorTests extends BaseMonitorClientInterceptorTests {
 
   override def name: String = "Prometheus"
 
+  override def namespace: Option[String] = Some("grpc")
+
   def defaultClientRuntime: InterceptorsRuntime =
     InterceptorsRuntime(Configuration.defaultBasicMetrics)
 

--- a/modules/prometheus/client/src/test/scala/NamespaceClientTests.scala
+++ b/modules/prometheus/client/src/test/scala/NamespaceClientTests.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc
+package prometheus
+package client
+
+import freestyle.rpc.common._
+import freestyle.rpc.interceptors.metrics._
+import freestyle.rpc.prometheus.shared.Configuration
+import freestyle.rpc.protocol.Utils.client.MyRPCClient
+import io.prometheus.client.CollectorRegistry
+import org.scalatest.{Assertion, OptionValues}
+
+import scala.collection.JavaConverters._
+
+class NamespaceClientTests extends RpcBaseTestSuite with OptionValues {
+
+  import freestyle.rpc.prometheus.shared.RegistryHelper._
+  import freestyle.rpc.protocol.Utils.database._
+
+  val namespace: String                   = "custom_nsp"
+  lazy val maybeNamespace: Option[String] = Some(namespace)
+
+  s"Client Metrics allows custom namespaces" should {
+
+    "work for Client Metrics" in {
+
+      def clientProgram[F[_]](implicit APP: MyRPCClient[F]): F[C] =
+        APP.u(a1.x, a1.y)
+
+      def check(implicit CR: CollectorRegistry): ConcurrentMonad[Assertion] = suspendM {
+        val startedTotal: Double = extractMetricValue(clientMetricRpcStarted(maybeNamespace))
+        startedTotal should be >= 0d
+        startedTotal should be <= 1d
+        findRecordedMetricOrThrow(clientMetricStreamMessagesReceived(maybeNamespace)).samples shouldBe empty
+        findRecordedMetricOrThrow(clientMetricStreamMessagesSent(maybeNamespace)).samples shouldBe empty
+
+        val handledSamples =
+          findRecordedMetricOrThrow(clientMetricRpcCompleted(maybeNamespace)).samples.asScala.toList
+        handledSamples.headOption.map(_.name shouldBe s"${namespace}_client_completed")
+        handledSamples.headOption should not be 'empty
+      }
+
+      val clientRuntime: InterceptorsRuntime =
+        InterceptorsRuntime(Configuration.defaultBasicMetrics.withNamespace(namespace))
+      import clientRuntime._
+
+      (for {
+        _         <- serverStart[ConcurrentMonad]
+        _         <- clientProgram[ConcurrentMonad]
+        assertion <- check
+        _         <- serverStop[ConcurrentMonad]
+      } yield assertion).unsafeRunSync()
+
+    }
+  }
+}

--- a/modules/prometheus/server/src/main/scala/ServerMetrics.scala
+++ b/modules/prometheus/server/src/main/scala/ServerMetrics.scala
@@ -27,19 +27,19 @@ case class ServerMetrics(cfg: Configuration) {
   import freestyle.rpc.prometheus.implicits._
 
   private[this] val serverStartedBuilder: Counter.Builder =
-    serverMetricRpcStarted.toCounterBuilder
+    serverMetricRpcStarted(cfg.namespace).toCounterBuilder
 
   private[this] val serverHandledBuilder: Counter.Builder =
-    serverMetricHandledCompleted.toCounterBuilder
+    serverMetricHandledCompleted(cfg.namespace).toCounterBuilder
 
   private[this] val serverHandledLatencySecondsBuilder: Histogram.Builder =
-    serverMetricHandledLatencySeconds.toHistogramBuilder
+    serverMetricHandledLatencySeconds(cfg.namespace).toHistogramBuilder
 
   private[this] val serverStreamMessagesReceivedBuilder: Counter.Builder =
-    serverMetricStreamMessagesReceived.toCounterBuilder
+    serverMetricStreamMessagesReceived(cfg.namespace).toCounterBuilder
 
   private[this] val serverStreamMessagesSentBuilder: Counter.Builder =
-    serverMetricStreamMessagesSent.toCounterBuilder
+    serverMetricStreamMessagesSent(cfg.namespace).toCounterBuilder
 
   val serverStarted: Counter = serverStartedBuilder.register(cfg.collectorRegistry)
 

--- a/modules/prometheus/server/src/test/scala/MonitorServerInterceptorTests.scala
+++ b/modules/prometheus/server/src/test/scala/MonitorServerInterceptorTests.scala
@@ -24,6 +24,8 @@ class MonitorServerInterceptorTests extends BaseMonitorServerInterceptorTests {
 
   override def name: String = "Prometheus"
 
+  override def namespace: Option[String] = Some("grpc")
+
   override def defaultInterceptorsRuntime: InterceptorsRuntime =
     InterceptorsRuntime(Configuration.defaultBasicMetrics)
 

--- a/modules/prometheus/server/src/test/scala/NamespaceServerTests.scala
+++ b/modules/prometheus/server/src/test/scala/NamespaceServerTests.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017-2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package freestyle.rpc
+package prometheus
+package server
+
+import freestyle.rpc.common._
+import freestyle.rpc.interceptors.metrics._
+import freestyle.rpc.prometheus.shared.Configuration
+import freestyle.rpc.protocol.Utils.client.MyRPCClient
+import org.scalatest.OptionValues
+
+import scala.collection.JavaConverters._
+
+class NamespaceServerTests extends RpcBaseTestSuite with OptionValues {
+
+  import freestyle.rpc.prometheus.shared.RegistryHelper._
+  import freestyle.rpc.protocol.Utils.database._
+
+  val namespace: String                   = "custom_nsp"
+  lazy val maybeNamespace: Option[String] = Some(namespace)
+
+  s"Server Metrics allows custom namespaces" should {
+
+    "work for Server Metrics" in {
+
+      def clientProgram[F[_]](implicit APP: MyRPCClient[F]): F[C] =
+        APP.u(a1.x, a1.y)
+
+      val serverRuntime: InterceptorsRuntime =
+        InterceptorsRuntime(Configuration.defaultBasicMetrics.withNamespace(namespace))
+
+      import serverRuntime._
+
+      (for {
+        _ <- serverStart[ConcurrentMonad]
+        _ <- clientProgram[ConcurrentMonad]
+        _ <- serverStop[ConcurrentMonad]
+      } yield (): Unit).unsafeRunSync()
+
+      findRecordedMetricOrThrow(serverMetricRpcStarted(maybeNamespace)).samples.size() shouldBe 1
+      findRecordedMetricOrThrow(serverMetricStreamMessagesReceived(maybeNamespace)).samples shouldBe empty
+      findRecordedMetricOrThrow(serverMetricStreamMessagesSent(maybeNamespace)).samples shouldBe empty
+
+      val handledSamples =
+        findRecordedMetricOrThrow(serverMetricHandledCompleted(maybeNamespace)).samples.asScala.toList
+      handledSamples.headOption.map(_.name shouldBe s"${namespace}_server_handled_total")
+      handledSamples.headOption should not be 'empty
+    }
+  }
+}

--- a/modules/prometheus/shared/src/main/scala/Configuration.scala
+++ b/modules/prometheus/shared/src/main/scala/Configuration.scala
@@ -23,13 +23,16 @@ import io.prometheus.client.CollectorRegistry
 case class Configuration(
     isIncludeLatencyHistograms: Boolean,
     collectorRegistry: CollectorRegistry,
-    latencyBuckets: Vector[Double]) {
+    latencyBuckets: Vector[Double],
+    namespace: Option[String] = None) {
 
   def withCollectorRegistry(c: CollectorRegistry): Configuration =
     this.copy(collectorRegistry = c)
 
   def withLatencyBuckets(lb: Vector[Double]): Configuration =
     this.copy(latencyBuckets = lb)
+
+  def withNamespace(namespace: String): Configuration = this.copy(namespace = Some(namespace))
 
 }
 


### PR DESCRIPTION
This PR allows providing externally the namespace for the registered metrics. Example:

```scala
val configList: List[ManagedChannelConfig] =
        AddInterceptor(
          MonitoringClientInterceptor(
            Configuration
              .defaultAllMetrics
              .withCollectorRegistry(CR)
              .withNamespace("custom_namespace")
          )
        )
```

`.withNamespace("custom_namespace")` is the combinator added here. If it's not provided, by default will be `grpc`, the same used until now.