### PR TITLE
Depending on Execution Context instead of Monix Scheduler

### DIFF
--- a/benchmarks/src/main/scala/shared/Runtime.scala
+++ b/benchmarks/src/main/scala/shared/Runtime.scala
@@ -20,10 +20,11 @@ package shared
 import cats.effect.IO
 import freestyle.rpc.ChannelForAddress
 
+import scala.concurrent.ExecutionContext
+
 trait Runtime {
 
-  implicit val S: monix.execution.Scheduler =
-    monix.execution.Scheduler.Implicits.global
+  implicit val EC: ExecutionContext = ExecutionContext.Implicits.global
 
   implicit val persistenceService: PersistenceService[IO] = PersistenceService[IO]
 

--- a/build.sbt
+++ b/build.sbt
@@ -258,7 +258,6 @@ lazy val `example-todolist-runtime` = project
   .in(file("modules/examples/todolist/runtime"))
   .settings(noPublishSettings)
   .settings(moduleName := "frees-rpc-example-todolist-runtime")
-  .settings(exampleTodolistRuntimeSettings)
   .disablePlugins(ScriptedPlugin)
 
 lazy val `example-todolist-server` = project

--- a/modules/examples/routeguide/runtime/src/main/scala/RouteGuide.scala
+++ b/modules/examples/routeguide/runtime/src/main/scala/RouteGuide.scala
@@ -26,11 +26,11 @@ trait RouteGuide {
   implicit val S: Scheduler = Scheduler.Implicits.global
 
   implicit def T2IO(implicit S: Scheduler): Task ~> IO = new (Task ~> IO) {
-    override def apply[A](fa: Task[A]) = fa.toIO
+    override def apply[A](fa: Task[A]): IO[A] = fa.toIO
   }
 
-  implicit def T2Task(implicit S: Scheduler): Task ~> Task = new (Task ~> Task) {
-    override def apply[A](fa: Task[A]) = fa
+  implicit def T2Task: Task ~> Task = new (Task ~> Task) {
+    override def apply[A](fa: Task[A]): Task[A] = fa
   }
 
 }

--- a/modules/examples/todolist/runtime/src/main/scala/CommonRuntime.scala
+++ b/modules/examples/todolist/runtime/src/main/scala/CommonRuntime.scala
@@ -16,10 +16,10 @@
 
 package examples.todolist.runtime
 
-import monix.execution.Scheduler
+import scala.concurrent.ExecutionContext
 
 trait CommonRuntime {
 
-  implicit val S: Scheduler = Scheduler.Implicits.global
+  implicit val EC: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
 
 }

--- a/modules/internal/src/main/scala/LiftTask.scala
+++ b/modules/internal/src/main/scala/LiftTask.scala
@@ -21,6 +21,8 @@ import cats.effect.LiftIO
 import monix.eval.Task
 import monix.execution.Scheduler
 
+import scala.concurrent.ExecutionContext
+
 trait LiftTask[F[_]] {
   def liftTask[A](task: Task[A]): F[A]
 }
@@ -31,8 +33,8 @@ object LiftTask {
       def liftTask[A](task: Task[A]): Task[A] = task
     }
 
-  implicit def effectLiftTask[F[_]](implicit F: LiftIO[F], s: Scheduler): LiftTask[F] =
+  implicit def effectLiftTask[F[_]](implicit F: LiftIO[F], EC: ExecutionContext): LiftTask[F] =
     new LiftTask[F] {
-      def liftTask[A](task: Task[A]): F[A] = F.liftIO(task.toIO(s))
+      def liftTask[A](task: Task[A]): F[A] = F.liftIO(task.toIO(Scheduler(EC)))
     }
 }

--- a/modules/internal/src/main/scala/server/monixCalls.scala
+++ b/modules/internal/src/main/scala/server/monixCalls.scala
@@ -27,7 +27,7 @@ import io.grpc.stub.ServerCalls.{
 }
 import io.grpc.stub.StreamObserver
 import io.grpc.{Status, StatusException, StatusRuntimeException}
-import monix.execution.Scheduler
+import scala.concurrent.ExecutionContext
 import monix.reactive.Observable
 
 object monixCalls {
@@ -48,7 +48,8 @@ object monixCalls {
 
   def clientStreamingMethod[F[_]: Effect, Req, Res](
       f: Observable[Req] => F[Res],
-      maybeCompression: Option[String])(implicit S: Scheduler): ClientStreamingMethod[Req, Res] =
+      maybeCompression: Option[String])(
+      implicit EC: ExecutionContext): ClientStreamingMethod[Req, Res] =
     new ClientStreamingMethod[Req, Res] {
 
       override def invoke(responseObserver: StreamObserver[Res]): StreamObserver[Req] = {
@@ -62,7 +63,8 @@ object monixCalls {
 
   def serverStreamingMethod[F[_]: Effect, Req, Res](
       f: Req => Observable[Res],
-      maybeCompression: Option[String])(implicit S: Scheduler): ServerStreamingMethod[Req, Res] =
+      maybeCompression: Option[String])(
+      implicit EC: ExecutionContext): ServerStreamingMethod[Req, Res] =
     new ServerStreamingMethod[Req, Res] {
 
       override def invoke(request: Req, responseObserver: StreamObserver[Res]): Unit = {
@@ -74,7 +76,8 @@ object monixCalls {
 
   def bidiStreamingMethod[F[_]: Effect, Req, Res](
       f: Observable[Req] => Observable[Res],
-      maybeCompression: Option[String])(implicit S: Scheduler): BidiStreamingMethod[Req, Res] =
+      maybeCompression: Option[String])(
+      implicit EC: ExecutionContext): BidiStreamingMethod[Req, Res] =
     new BidiStreamingMethod[Req, Res] {
 
       override def invoke(responseObserver: StreamObserver[Res]): StreamObserver[Req] = {

--- a/modules/internal/src/main/scala/server/package.scala
+++ b/modules/internal/src/main/scala/server/package.scala
@@ -22,7 +22,7 @@ import monix.execution.{Ack, Scheduler}
 import monix.reactive.{Observable, Observer, Pipe}
 import monix.reactive.observers.Subscriber
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 package object server {
 
@@ -47,7 +47,7 @@ package object server {
   private[server] def transformStreamObserver[Req, Res](
       transformer: Observable[Req] => Observable[Res],
       responseObserver: StreamObserver[Res]
-  )(implicit S: Scheduler): StreamObserver[Req] =
+  )(implicit EC: ExecutionContext): StreamObserver[Req] =
     transform(transformer, responseObserver.toSubscriber).toStreamObserver
 
   private[server] def addCompression[A](

--- a/modules/internal/src/main/scala/service.scala
+++ b/modules/internal/src/main/scala/service.scala
@@ -175,7 +175,7 @@ object serviceImpl {
         def bindService[$F_](implicit
           F: _root_.cats.effect.Effect[$F],
           algebra: $serviceName[$F],
-          S: _root_.monix.execution.Scheduler
+          EC: _root_.scala.concurrent.ExecutionContext
         ): _root_.io.grpc.ServerServiceDefinition =
           new _root_.freestyle.rpc.internal.service.GRPCServiceDefBuilder(${lit(serviceName)}, ..$serverCallDescriptorsAndHandlers).apply
         """
@@ -189,7 +189,7 @@ object serviceImpl {
           options: _root_.io.grpc.CallOptions = _root_.io.grpc.CallOptions.DEFAULT
         )(implicit
           F: _root_.cats.effect.Effect[$F],
-          S: _root_.monix.execution.Scheduler
+          EC: _root_.scala.concurrent.ExecutionContext
         ) extends _root_.io.grpc.stub.AbstractStub[$Client[$F]](channel, options) {
           override def build(channel: _root_.io.grpc.Channel, options: _root_.io.grpc.CallOptions): $Client[F] =
               new $Client[$F](channel, options)
@@ -206,7 +206,7 @@ object serviceImpl {
             options: _root_.io.grpc.CallOptions = _root_.io.grpc.CallOptions.DEFAULT
           )(implicit
           F: _root_.cats.effect.Effect[$F],
-          S: _root_.monix.execution.Scheduler
+          EC: _root_.scala.concurrent.ExecutionContext
         ): $Client[$F] = {
           val managedChannelInterpreter =
             new _root_.freestyle.rpc.client.ManagedChannelInterpreter[F](channelFor, channelConfigList)
@@ -220,7 +220,7 @@ object serviceImpl {
           options: _root_.io.grpc.CallOptions = _root_.io.grpc.CallOptions.DEFAULT
         )(implicit
           F: _root_.cats.effect.Effect[$F],
-          S: _root_.monix.execution.Scheduler
+          EC: _root_.scala.concurrent.ExecutionContext
         ): $Client[$F] = new $Client[$F](channel, options)
         """.supressWarts("DefaultArguments")
 

--- a/modules/marshallers/jodatime/src/test/scala/RPCJodaLocalDateTests.scala
+++ b/modules/marshallers/jodatime/src/test/scala/RPCJodaLocalDateTests.scala
@@ -85,7 +85,7 @@ class RPCJodaLocalDateTests extends RpcBaseTestSuite with BeforeAndAfterAll with
   "RPCJodaService" should {
 
     import RPCJodaLocalDateService._
-    import monix.execution.Scheduler.Implicits.global
+    import scala.concurrent.ExecutionContext.Implicits.global
 
     implicit val H: RPCLocalDateServiceDefHandler[ConcurrentMonad] =
       new RPCLocalDateServiceDefHandler[ConcurrentMonad]

--- a/modules/marshallers/jodatime/src/test/scala/RPCJodaLocalDateTimeTests.scala
+++ b/modules/marshallers/jodatime/src/test/scala/RPCJodaLocalDateTimeTests.scala
@@ -86,7 +86,7 @@ class RPCJodaLocalDateTimeTests extends RpcBaseTestSuite with BeforeAndAfter wit
   "RPCJodaService" should {
 
     import RPCJodaLocalDateTimeService._
-    import monix.execution.Scheduler.Implicits.global
+    import scala.concurrent.ExecutionContext.Implicits.global
 
     implicit val H: RPCJodaServiceDefHandler[ConcurrentMonad] =
       new RPCJodaServiceDefHandler[ConcurrentMonad]

--- a/modules/server/src/test/scala/CommonUtils.scala
+++ b/modules/server/src/test/scala/CommonUtils.scala
@@ -74,7 +74,8 @@ trait CommonUtils {
 
   def debug(str: String): Unit = logger.debug(str)
 
-  implicit val S: monix.execution.Scheduler = monix.execution.Scheduler.Implicits.global
+  implicit val EC: scala.concurrent.ExecutionContext =
+    scala.concurrent.ExecutionContext.Implicits.global
 
   val pickUnusedPort: Int =
     Try {

--- a/modules/server/src/test/scala/protocol/RPCBigDecimalTests.scala
+++ b/modules/server/src/test/scala/protocol/RPCBigDecimalTests.scala
@@ -75,7 +75,7 @@ class RPCBigDecimalTests extends RpcBaseTestSuite with BeforeAndAfterAll with Ch
   "A RPC server" should {
 
     import RPCService._
-    import monix.execution.Scheduler.Implicits.global
+    import scala.concurrent.ExecutionContext.Implicits.global
 
     implicit val H: RPCServiceDefImpl[ConcurrentMonad] = new RPCServiceDefImpl[ConcurrentMonad]
 

--- a/modules/server/src/test/scala/protocol/RPCJavaTimeTests.scala
+++ b/modules/server/src/test/scala/protocol/RPCJavaTimeTests.scala
@@ -87,7 +87,7 @@ class RPCJavaTimeTests extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
   "A RPC server" should {
 
     import RPCDateService._
-    import monix.execution.Scheduler.Implicits.global
+    import scala.concurrent.ExecutionContext.Implicits.global
 
     implicit val H: RPCDateServiceDefImpl[ConcurrentMonad] =
       new RPCDateServiceDefImpl[ConcurrentMonad]

--- a/modules/server/src/test/scala/protocol/RPCProtoProducts.scala
+++ b/modules/server/src/test/scala/protocol/RPCProtoProducts.scala
@@ -82,7 +82,7 @@ class RPCProtoProducts extends RpcBaseTestSuite with BeforeAndAfterAll with Chec
   "A RPC server" should {
 
     import RPCService._
-    import monix.execution.Scheduler.Implicits.global
+    import scala.concurrent.ExecutionContext.Implicits.global
 
     implicit val H: RPCServiceDefImpl[ConcurrentMonad] =
       new RPCServiceDefImpl[ConcurrentMonad]

--- a/modules/server/src/test/scala/protocol/Utils.scala
+++ b/modules/server/src/test/scala/protocol/Utils.scala
@@ -22,6 +22,7 @@ import cats.effect.Async
 import cats.syntax.applicative._
 import freestyle.rpc.common._
 import io.grpc.Status
+import monix.execution.Scheduler
 import monix.reactive.Observable
 
 object Utils extends CommonUtils {
@@ -132,6 +133,8 @@ object Utils extends CommonUtils {
           with CompressedProtoRPCService[F]
           with CompressedAvroRPCService[F]
           with CompressedAvroWithSchemaRPCService[F] {
+
+        implicit val S: Scheduler = Scheduler(EC)
 
         def notAllowed(b: Boolean): F[C] = c1.pure
 
@@ -267,6 +270,8 @@ object Utils extends CommonUtils {
           M: MonadError[F, Throwable])
           extends MyRPCClient[F] {
 
+        implicit val S: Scheduler = Scheduler(EC)
+
         override def notAllowed(b: Boolean): F[C] =
           proto.notAllowed(b)
 
@@ -374,6 +379,8 @@ object Utils extends CommonUtils {
           avro: CompressedAvroRPCService.Client[F],
           M: MonadError[F, Throwable])
           extends MyRPCClient[F] {
+
+        implicit val S: Scheduler = Scheduler(EC)
 
         override def notAllowed(b: Boolean): F[C] =
           proto.notAllowedCompressed(b)

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -165,12 +165,6 @@ object ProjectPlugin extends AutoPlugin {
       )
     )
 
-    lazy val exampleTodolistRuntimeSettings: Seq[Def.Setting[_]] = Seq(
-      libraryDependencies ++= Seq(
-        %%("monix", V.monix)
-      )
-    )
-
     lazy val exampleTodolistCommonSettings: Seq[Def.Setting[_]] = Seq(
       libraryDependencies ++= Seq(
         "io.frees" %% "frees-todolist-lib" % V.frees,


### PR DESCRIPTION
This PR replaces, where possible, the `monix.execution.Scheduler` dependency by `scala.concurrent.ExecutionContext`. Therefore, _RPC clients_ (based on RPC protocols) that are not depending on `Monix` in its classpath can interact with the RPC services without needing to add it.