### PR TITLE
Upgrades Build Dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,6 @@ lazy val common = project
   .in(file("modules/common"))
   .settings(moduleName := "frees-rpc-common")
   .settings(commonSettings)
-  .disablePlugins(ScriptedPlugin)
 
 lazy val internal = project
   .in(file("modules/internal"))
@@ -20,13 +19,11 @@ lazy val internal = project
   .dependsOn(testing % "test->test")
   .settings(moduleName := "frees-rpc-internal")
   .settings(internalSettings)
-  .disablePlugins(ScriptedPlugin)
 
 lazy val testing = project
   .in(file("modules/testing"))
   .settings(moduleName := "frees-rpc-testing")
   .settings(testingSettings)
-  .disablePlugins(ScriptedPlugin)
 
 lazy val ssl = project
   .in(file("modules/ssl"))
@@ -34,7 +31,6 @@ lazy val ssl = project
   .dependsOn(`client-netty` % "compile->compile;test->test")
   .settings(moduleName := "frees-rpc-netty-ssl")
   .settings(nettySslSettings)
-  .disablePlugins(ScriptedPlugin)
 
 lazy val config = project
   .in(file("modules/config"))
@@ -44,7 +40,6 @@ lazy val config = project
   .dependsOn(testing % "test->test")
   .settings(moduleName := "frees-rpc-config")
   .settings(configSettings)
-  .disablePlugins(ScriptedPlugin)
 
 ////////////////
 //// CLIENT ////
@@ -57,27 +52,23 @@ lazy val client = project
   .dependsOn(testing % "test->test")
   .settings(moduleName := "frees-rpc-client-core")
   .settings(clientCoreSettings)
-  .disablePlugins(ScriptedPlugin)
 
 lazy val `client-netty` = project
   .in(file("modules/client-netty"))
   .dependsOn(client % "compile->compile;test->test")
   .settings(moduleName := "frees-rpc-client-netty")
   .settings(clientNettySettings)
-  .disablePlugins(ScriptedPlugin)
 
 lazy val `client-okhttp` = project
   .in(file("modules/client-okhttp"))
   .dependsOn(client % "compile->compile;test->test")
   .settings(moduleName := "frees-rpc-client-okhttp")
   .settings(clientOkHttpSettings)
-  .disablePlugins(ScriptedPlugin)
 
 lazy val `client-cache` = project
   .in(file("modules/client-cache"))
   .settings(moduleName := "frees-rpc-client-cache")
   .settings(clientCacheSettings)
-  .disablePlugins(ScriptedPlugin)
 
 ////////////////
 //// SERVER ////
@@ -91,7 +82,6 @@ lazy val server = project
   .dependsOn(testing % "test->test")
   .settings(moduleName := "frees-rpc-server")
   .settings(serverSettings)
-  .disablePlugins(ScriptedPlugin)
 
 //////////////////////
 //// INTERCEPTORS ////
@@ -101,7 +91,6 @@ lazy val interceptors = project
   .in(file("modules/interceptors"))
   .settings(moduleName := "frees-rpc-interceptors")
   .settings(interceptorsSettings)
-  .disablePlugins(ScriptedPlugin)
 
 ////////////////////
 //// PROMETHEUS ////
@@ -112,14 +101,12 @@ lazy val `prometheus-shared` = project
   .dependsOn(interceptors % "compile->compile;test->test")
   .settings(moduleName := "frees-rpc-prometheus-shared")
   .settings(prometheusSettings)
-  .disablePlugins(ScriptedPlugin)
 
 lazy val `prometheus-server` = project
   .in(file("modules/prometheus/server"))
   .dependsOn(`prometheus-shared` % "compile->compile;test->test")
   .dependsOn(server % "compile->compile;test->test")
   .settings(moduleName := "frees-rpc-prometheus-server")
-  .disablePlugins(ScriptedPlugin)
 
 lazy val `prometheus-client` = project
   .in(file("modules/prometheus/client"))
@@ -128,7 +115,6 @@ lazy val `prometheus-client` = project
   .dependsOn(server % "test->test")
   .settings(moduleName := "frees-rpc-prometheus-client")
   .settings(prometheusClientSettings)
-  .disablePlugins(ScriptedPlugin)
 
 ////////////////////
 //// DROPWIZARD ////
@@ -140,7 +126,6 @@ lazy val `dropwizard-server` = project
   .dependsOn(server % "compile->compile;test->test")
   .settings(moduleName := "frees-rpc-dropwizard-server")
   .settings(dropwizardSettings)
-  .disablePlugins(ScriptedPlugin)
 
 lazy val `dropwizard-client` = project
   .in(file("modules/dropwizard/client"))
@@ -149,7 +134,6 @@ lazy val `dropwizard-client` = project
   .dependsOn(server % "test->test")
   .settings(moduleName := "frees-rpc-dropwizard-client")
   .settings(dropwizardSettings)
-  .disablePlugins(ScriptedPlugin)
 
 ////////////////
 //// IDLGEN ////
@@ -161,18 +145,17 @@ lazy val `idlgen-core` = project
   .dependsOn(client % "test->test")
   .settings(moduleName := "frees-rpc-idlgen-core")
   .settings(idlGenSettings)
-  .disablePlugins(ScriptedPlugin)
 
 lazy val `idlgen-sbt` = project
   .in(file("modules/idlgen/plugin"))
   .dependsOn(`idlgen-core`)
   .settings(moduleName := "sbt-frees-rpc-idlgen")
-  .settings(sbtPlugin := true)
   .settings(crossScalaVersions := Seq(scalac.`2.12`))
   .settings(sbtPluginSettings: _*)
   .enablePlugins(BuildInfoPlugin)
   .settings(buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion))
   .settings(buildInfoPackage := "freestyle.rpc.idlgen")
+  .enablePlugins(SbtPlugin)
 
 ////////////////////
 //// BENCHMARKS ////
@@ -183,7 +166,6 @@ lazy val benchmarks = project
   .dependsOn(client)
   .dependsOn(server)
   .settings(moduleName := "frees-rpc-benchmarks")
-  .disablePlugins(ScriptedPlugin)
   .enablePlugins(JmhPlugin)
 
 //////////////////
@@ -199,14 +181,12 @@ lazy val `example-routeguide-protocol` = project
   .dependsOn(client)
   .settings(noPublishSettings)
   .settings(moduleName := "frees-rpc-example-routeguide-protocol")
-  .disablePlugins(ScriptedPlugin)
 
 lazy val `example-routeguide-runtime` = project
   .in(file("modules/examples/routeguide/runtime"))
   .settings(noPublishSettings)
   .settings(moduleName := "frees-rpc-example-routeguide-runtime")
   .settings(exampleRouteguideRuntimeSettings)
-  .disablePlugins(ScriptedPlugin)
 
 lazy val `example-routeguide-common` = project
   .in(file("modules/examples/routeguide/common"))
@@ -215,7 +195,6 @@ lazy val `example-routeguide-common` = project
   .settings(noPublishSettings)
   .settings(moduleName := "frees-rpc-example-routeguide-common")
   .settings(exampleRouteguideCommonSettings)
-  .disablePlugins(ScriptedPlugin)
 
 lazy val `example-routeguide-server` = project
   .in(file("modules/examples/routeguide/server"))
@@ -224,7 +203,6 @@ lazy val `example-routeguide-server` = project
   .dependsOn(server)
   .settings(noPublishSettings)
   .settings(moduleName := "frees-rpc-example-routeguide-server")
-  .disablePlugins(ScriptedPlugin)
 
 lazy val `example-routeguide-client` = project
   .in(file("modules/examples/routeguide/client"))
@@ -240,8 +218,8 @@ lazy val `example-routeguide-client` = project
     )
   )
   .settings(addCommandAlias("runClientIO", "runMain example.routeguide.client.io.ClientAppIO"))
-  .settings(addCommandAlias("runClientTask", "runMain example.routeguide.client.task.ClientAppTask"))
-  .disablePlugins(ScriptedPlugin)
+  .settings(
+    addCommandAlias("runClientTask", "runMain example.routeguide.client.task.ClientAppTask"))
 
 ////////////////////
 ////  TODOLIST  ////
@@ -252,13 +230,11 @@ lazy val `example-todolist-protocol` = project
   .dependsOn(client)
   .settings(noPublishSettings)
   .settings(moduleName := "frees-rpc-example-todolist-protocol")
-  .disablePlugins(ScriptedPlugin)
 
 lazy val `example-todolist-runtime` = project
   .in(file("modules/examples/todolist/runtime"))
   .settings(noPublishSettings)
   .settings(moduleName := "frees-rpc-example-todolist-runtime")
-  .disablePlugins(ScriptedPlugin)
 
 lazy val `example-todolist-server` = project
   .in(file("modules/examples/todolist/server"))
@@ -269,7 +245,6 @@ lazy val `example-todolist-server` = project
   .settings(noPublishSettings)
   .settings(moduleName := "frees-rpc-example-todolist-server")
   .settings(exampleTodolistCommonSettings)
-  .disablePlugins(ScriptedPlugin)
 
 lazy val `example-todolist-client` = project
   .in(file("modules/examples/todolist/client"))
@@ -280,7 +255,6 @@ lazy val `example-todolist-client` = project
   .settings(noPublishSettings)
   .settings(moduleName := "frees-rpc-example-todolist-client")
   .settings(exampleTodolistCommonSettings)
-  .disablePlugins(ScriptedPlugin)
 
 /////////////////////
 //// MARSHALLERS ////
@@ -293,9 +267,7 @@ lazy val `marshallers-jodatime` = project
   .dependsOn(internal % "compile->compile;test->test")
   .dependsOn(testing % "test->test")
   .settings(moduleName := "frees-rpc-marshallers-jodatime")
-  .settings(libraryDependencies += "joda-time" % "joda-time" % "2.9.9")
-  .settings(libraryDependencies += "com.47deg" %% "scalacheck-toolbox-datetime" % "0.2.4" % "test")
-  .disablePlugins(ScriptedPlugin)
+  .settings(marshallersJodatimeSettings)
 
 //////////////////////////
 //// MODULES REGISTRY ////
@@ -341,7 +313,6 @@ lazy val root = project
   .settings(noPublishSettings)
   .aggregate(allModules: _*)
   .dependsOn(allModulesDeps: _*)
-  .disablePlugins(ScriptedPlugin)
 
 lazy val docs = project
   .in(file("docs"))

--- a/modules/idlgen/core/src/test/scala/AvroScalaGeneratorArbitrary.scala
+++ b/modules/idlgen/core/src/test/scala/AvroScalaGeneratorArbitrary.scala
@@ -44,9 +44,9 @@ trait AvroScalaGeneratorArbitrary {
          |
          |$imports
          |
-         |@message case class HelloRequest(arg1: String, arg2: Option[String], arg3: List[String])
+         |@message case class HelloRequest(arg1: String, arg2: Option[String], arg3: Seq[String])
          |
-         |@message case class HelloResponse(arg1: String, arg2: Option[String], arg3: List[String])
+         |@message case class HelloResponse(arg1: String, arg2: Option[String], arg3: Seq[String])
          |
          |@service(${(serializationType +: options.toSeq).mkString(", ")}) trait MyGreeterService[F[_]] {
          |

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -20,28 +20,32 @@ object ProjectPlugin extends AutoPlugin {
 
     lazy val V = new {
       val avro4s: String             = "1.8.3"
-      val avrohugger: String         = "1.0.0-RC10"
+      val avrohugger: String         = "1.0.0-RC13"
       val betterMonadicFor: String   = "0.2.4"
       val catsEffect: String         = "0.10.1"
       val circe: String              = "0.9.3"
-      val frees: String              = "0.8.1"
-      val fs2: String                = "0.10.5"
+      val frees: String              = "0.8.2"
+      val fs2: String                = "0.10.6"
       val fs2ReactiveStreams: String = "0.5.1"
-      val grpc: String               = "1.13.2"
+      val jodaTime: String           = "2.10"
+      val grpc: String               = "1.15.0"
       val log4s: String              = "1.6.1"
       val logback: String            = "1.2.3"
       val monix: String              = "3.0.0-RC1"
-      val nettySSL: String           = "2.0.8.Final"
+      val monocle: String            = "1.5.1-cats"
+      val nettySSL: String           = "2.0.12.Final"
+      val paradise: String           = "2.1.1"
       val pbdirect: String           = "0.1.0"
-      val prometheus: String         = "0.3.0"
-      val monocle: String            = "1.5.0-cats"
+      val prometheus: String         = "0.5.0"
+      val pureconfig: String         = "0.9.2"
+      val scalacheckToolbox: String  = "0.2.5"
     }
 
     lazy val commonSettings: Seq[Def.Setting[_]] = Seq(
       libraryDependencies ++= Seq(
-        %%("cats-effect", V.catsEffect) % Test,
-        %%("scalamockScalatest")        % Test,
-        %%("scheckToolboxDatetime")     % Test
+        %%("cats-effect", V.catsEffect)                  % Test,
+        %%("scalamockScalatest")                         % Test,
+        %%("scheckToolboxDatetime", V.scalacheckToolbox) % Test
       )
     )
 
@@ -101,7 +105,7 @@ object ProjectPlugin extends AutoPlugin {
 
     lazy val configSettings = Seq(
       libraryDependencies ++= Seq(
-        %%("pureconfig")
+        %%("pureconfig", V.pureconfig)
       )
     )
 
@@ -155,6 +159,13 @@ object ProjectPlugin extends AutoPlugin {
       )
     )
 
+    lazy val marshallersJodatimeSettings: Seq[Def.Setting[_]] = Seq(
+      libraryDependencies ++= Seq(
+        %("joda-time", V.jodaTime),
+        %%("scheckToolboxDatetime", V.scalacheckToolbox) % Test
+      )
+    )
+
     lazy val exampleRouteguideCommonSettings: Seq[Def.Setting[_]] = Seq(
       libraryDependencies ++= Seq(
         %%("circe-core", V.circe),
@@ -198,10 +209,12 @@ object ProjectPlugin extends AutoPlugin {
 
   }
 
+  import autoImport._
+
   override def projectSettings: Seq[Def.Setting[_]] =
     // format: OFF
     sharedReleaseProcess ++ warnUnusedImport ++ Seq(
-      addCompilerPlugin(%%("paradise") cross CrossVersion.full),
+      addCompilerPlugin(%%("paradise", V.paradise) cross CrossVersion.full),
       libraryDependencies ++= commonDeps :+ %("slf4j-nop") % Test,
       scalaVersion := "2.12.6",
       crossScalaVersions := Seq("2.11.12", "2.12.6"),

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.1.6
+sbt.version = 1.2.3


### PR DESCRIPTION
This PR bumps up the dependency except the ones related to `cats-effect` which has binary incompatibilities with the latest monix release (we still need to wait for the 3.0.0 final release).

At `sbt` level, I'm upgrading to `1.2.3`, where the `ScriptedPlugin` is no longer auto-triggered. Also, from sbt `1.2.0`, specifying `enablePlugins(SbtPlugin)` enables by default the scripted tests and the setting `sbtPlugin := true`.