### PR TITLE
Releases 0.15.0 frees-rpc Version

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.14.2-SNAPSHOT"
+version in ThisBuild := "0.15.0"


### PR DESCRIPTION
This PR proposes to release a new minor version of `frees-rpc`: *0.15.0*. It's a minor version due to some breaking changes introduced in the last merged PRs.